### PR TITLE
chore: add OSS health files (LICENSE, CI, tests, community docs)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,95 @@
+name: Bug report
+description: A build was not cached, or a cached build was not reused.
+labels: ["bug", "needs triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Cache bugs are usually about *fingerprints* — two builds you expect to
+        match produce different hashes, or a stale artifact gets reused. The
+        Expo CLI output around "Searching for cached build with fingerprint"
+        is the most useful thing you can paste here.
+
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      placeholder: |
+        Every `expo run:ios` rebuilds from scratch even though nothing changed,
+        and the log always says "Cache miss".
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: What did you expect instead?
+    validations:
+      required: true
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Expo CLI output
+      description: Include the "Searching for cached build with fingerprint ..." lines.
+      render: shell
+    validations:
+      required: true
+
+  - type: textarea
+    id: config
+    attributes:
+      label: Your buildCacheProvider config
+      description: The `experiments.buildCacheProvider` block from app.config.ts / app.json.
+      render: typescript
+    validations:
+      required: true
+
+  - type: input
+    id: version
+    attributes:
+      label: eas-local-cache version
+      placeholder: 1.0.3
+    validations:
+      required: true
+
+  - type: input
+    id: expo-version
+    attributes:
+      label: Expo SDK and Expo CLI version
+      placeholder: SDK 54, @expo/cli 0.24.x
+    validations:
+      required: true
+
+  - type: input
+    id: os
+    attributes:
+      label: Operating system
+      placeholder: macOS 15.1 (Apple Silicon)
+    validations:
+      required: true
+
+  - type: checkboxes
+    id: platforms
+    attributes:
+      label: Platforms affected
+      options:
+        - label: iOS (.app bundle)
+        - label: Android (.apk)
+
+  - type: textarea
+    id: cache-dir
+    attributes:
+      label: Contents of .expo/cache
+      description: "Output of `ls -la .expo/cache` in your project root."
+      render: shell
+
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Before submitting
+      options:
+        - label: I tried clearing the cache (`rm -rf .expo/cache`) and reproducing again.
+          required: true
+        - label: I searched existing issues and did not find a duplicate.
+          required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Question or usage help
+    url: https://github.com/dennytosp/eas-local-cache/discussions
+    about: Ask how to wire the cache provider into your project.
+  - name: Expo build cache providers documentation
+    url: https://docs.expo.dev/guides/cache-builds-remotely/
+    about: How Expo's buildCacheProvider API works, including fingerprinting.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,31 @@
+name: Feature request
+description: Suggest an improvement to the local build cache.
+labels: ["enhancement", "needs triage"]
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: What problem are you trying to solve?
+      placeholder: |
+        My .expo/cache grows without bound across branches and eventually fills
+        the disk; I would like old entries pruned.
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed behaviour
+      description: What should the plugin do, and what should it configure through `buildCacheProvider.options`?
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: What have you tried already?
+
+  - type: checkboxes
+    id: contribute
+    attributes:
+      label: Contribution
+      options:
+        - label: I am willing to open a pull request for this.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,24 @@
+# Summary
+
+<!-- What does this change and why? Link the issue it closes, e.g. "Closes #4". -->
+
+## Type of change
+
+- [ ] Bug fix (no behaviour change for existing caches)
+- [ ] New feature
+- [ ] Breaking change (existing cache entries or config stop working)
+- [ ] Docs / internal only
+
+## How was this verified?
+
+- [ ] `bun run typecheck` passes
+- [ ] `bun test` passes
+- [ ] `bun run build` passes
+- [ ] Tried end to end in a real Expo project (say which platform below)
+
+<!-- iOS or Android, Expo SDK version, macOS or Linux. -->
+
+## Notes for reviewers
+
+<!-- Anything about cache invalidation, on-disk layout, or platform-specific
+     copy behaviour (ditto vs cp -R) that a reviewer should know. -->

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,20 @@
+version: 2
+
+updates:
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "chore(deps)"
+    groups:
+      dev-dependencies:
+        dependency-type: development
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    commit-message:
+      prefix: "chore(ci)"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
         os: [ubuntu-latest, macos-latest]
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - uses: oven-sh/setup-bun@v2
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,52 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+  workflow_dispatch:
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  verify:
+    name: Verify on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 10
+
+    strategy:
+      fail-fast: false
+      matrix:
+        # macOS matters here: the plugin prefers `ditto` for copying .app
+        # bundles and falls back to `cp -R` elsewhere. Both paths get exercised.
+        os: [ubuntu-latest, macos-latest]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Install dependencies
+        run: bun install
+
+      - name: Typecheck
+        run: bun run typecheck
+
+      - name: Test
+        run: bun test
+
+      - name: Build
+        run: bun run build
+
+      - name: Verify published files
+        run: |
+          test -f build/index.js
+          test -f build/index.d.ts
+          npm pack --dry-run

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,13 +24,13 @@ jobs:
     environment: npm
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - uses: oven-sh/setup-bun@v2
         with:
           bun-version: latest
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
           node-version: 22
           registry-url: https://registry.npmjs.org

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,63 @@
+name: Release
+
+# Publishes to npm when a GitHub Release is published.
+#
+# One-time setup required before the first run:
+#   1. Create an npm automation token (npmjs.com -> Access Tokens).
+#   2. Add it as the repository secret `NPM_TOKEN`
+#      (Settings -> Secrets and variables -> Actions).
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  publish:
+    name: Publish to npm
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    environment: npm
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          registry-url: https://registry.npmjs.org
+
+      - name: Install dependencies
+        run: bun install
+
+      - name: Typecheck
+        run: bun run typecheck
+
+      - name: Test
+        run: bun test
+
+      - name: Build
+        run: bun run build
+
+      - name: Check release tag matches package version
+        if: github.event_name == 'release'
+        run: |
+          PKG_VERSION="$(node -p "require('./package.json').version")"
+          TAG="${GITHUB_REF_NAME#v}"
+          if [ "$PKG_VERSION" != "$TAG" ]; then
+            echo "::error::Tag $GITHUB_REF_NAME does not match package.json version $PKG_VERSION"
+            exit 1
+          fi
+
+      - name: Publish
+        run: npm publish --provenance --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,8 +28,7 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: write # push the version tag and create the GitHub Release
-  id-token: write # OIDC for trusted publishing and provenance
+  contents: read
 
 concurrency:
   group: release
@@ -53,9 +52,40 @@ jobs:
           VERSION="$(node -p "require('./package.json').version")"
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
 
-          # `npm view pkg@version` exits non-zero when that exact version is
-          # not on the registry — which is precisely the case worth publishing.
-          if npm view "$NAME@$VERSION" version > /dev/null 2>&1; then
+          # Ask the registry once for every published version.
+          #
+          # `npm view pkg@version` exits non-zero both when the version is
+          # genuinely unpublished and when the registry is unreachable, so
+          # using it directly would read a network blip as "not released yet"
+          # and try to publish. Fetch the version list instead and tell the two
+          # cases apart explicitly.
+          set +e
+          VERSIONS="$(npm view "$NAME" versions --json 2>&1)"
+          STATUS=$?
+          set -e
+
+          if [ "$STATUS" -ne 0 ]; then
+            if printf '%s' "$VERSIONS" | grep -q 'E404'; then
+              echo "$NAME has never been published. Releasing $VERSION."
+              echo "publish=true" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
+            echo "::error::Could not reach the npm registry for $NAME"
+            printf '%s\n' "$VERSIONS"
+            exit 1
+          fi
+
+          # A package with a single published version returns a bare string
+          # rather than an array.
+          if printf '%s' "$VERSIONS" | node -e '
+            let raw = "";
+            process.stdin.on("data", (chunk) => (raw += chunk));
+            process.stdin.on("end", () => {
+              const parsed = JSON.parse(raw);
+              const all = Array.isArray(parsed) ? parsed : [parsed];
+              process.exit(all.includes(process.argv[1]) ? 0 : 1);
+            });
+          ' "$VERSION"; then
             echo "$NAME@$VERSION is already on npm. Nothing to release."
             echo "publish=false" >> "$GITHUB_OUTPUT"
           else
@@ -69,6 +99,10 @@ jobs:
     if: needs.check.outputs.publish == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 15
+
+    permissions:
+      contents: write # push the version tag and create the GitHub Release
+      id-token: write # OIDC for trusted publishing and provenance
 
     steps:
       - uses: actions/checkout@v5
@@ -111,19 +145,33 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           VERSION: ${{ needs.check.outputs.version }}
         run: |
-          git tag "v$VERSION"
-          git push origin "v$VERSION"
+          TAG="v$VERSION"
+
+          # npm is already published by this point, so a pre-existing tag or
+          # release is reported and stepped over rather than failing the run.
+          if git ls-remote --exit-code --tags origin "refs/tags/$TAG" > /dev/null 2>&1; then
+            echo "::notice::Tag $TAG already exists on the remote. Leaving it as is."
+          else
+            git tag "$TAG"
+            git push origin "$TAG"
+          fi
+
+          if gh release view "$TAG" > /dev/null 2>&1; then
+            echo "::notice::Release $TAG already exists. Leaving it as is."
+            exit 0
+          fi
 
           # Prefer the matching CHANGELOG section; fall back to generated notes
           # when this version has no entry.
+          NOTES="$RUNNER_TEMP/release-notes.md"
           awk -v header="## [$VERSION]" '
             index($0, header) == 1 { found = 1; next }
             found && /^## / { exit }
             found { print }
-          ' CHANGELOG.md > release-notes.md
+          ' CHANGELOG.md > "$NOTES"
 
-          if [ -s release-notes.md ] && grep -q '[^[:space:]]' release-notes.md; then
-            gh release create "v$VERSION" --title "v$VERSION" --notes-file release-notes.md
+          if grep -q '[^[:space:]]' "$NOTES"; then
+            gh release create "$TAG" --title "$TAG" --notes-file "$NOTES"
           else
-            gh release create "v$VERSION" --title "v$VERSION" --generate-notes
+            gh release create "$TAG" --title "$TAG" --generate-notes
           fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,27 +1,74 @@
 name: Release
 
-# Publishes to npm when a GitHub Release is published.
+# Publishes to npm when the version in package.json changes on `main`.
 #
-# One-time setup required before the first run:
-#   1. Create an npm automation token (npmjs.com -> Access Tokens).
-#   2. Add it as the repository secret `NPM_TOKEN`
-#      (Settings -> Secrets and variables -> Actions).
+# The semver decision stays human: bump `package.json` in a pull request.
+# Merging that pull request is what releases. Everything after the merge —
+# publish, tag, GitHub Release — happens here. Pushes that do not change the
+# version are compared against the registry and skipped, so ordinary commits
+# never publish.
+#
+# Authentication uses npm trusted publishing (OIDC). There is no token to
+# store or rotate. Configure it once, at
+# https://www.npmjs.com/package/eas-local-cache/access
+# -> Trusted Publisher:
+#
+#   Organization or user:  dennytosp
+#   Repository:            eas-local-cache
+#   Workflow filename:     release.yml
+#   Environment name:      (leave blank)
+#
+# Until a trusted publisher is configured, the workflow falls back to an
+# `NPM_TOKEN` repository secret if one exists.
 
 on:
-  release:
-    types: [published]
+  push:
+    branches: [main]
+    paths: ["package.json"]
   workflow_dispatch:
 
 permissions:
-  contents: read
-  id-token: write
+  contents: write # push the version tag and create the GitHub Release
+  id-token: write # OIDC for trusted publishing and provenance
+
+concurrency:
+  group: release
+  cancel-in-progress: false
 
 jobs:
-  publish:
-    name: Publish to npm
+  check:
+    name: Check for an unpublished version
     runs-on: ubuntu-latest
-    timeout-minutes: 10
-    environment: npm
+    timeout-minutes: 5
+    outputs:
+      version: ${{ steps.check.outputs.version }}
+      publish: ${{ steps.check.outputs.publish }}
+
+    steps:
+      - uses: actions/checkout@v5
+
+      - id: check
+        run: |
+          NAME="$(node -p "require('./package.json').name")"
+          VERSION="$(node -p "require('./package.json').version")"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+
+          # `npm view pkg@version` exits non-zero when that exact version is
+          # not on the registry — which is precisely the case worth publishing.
+          if npm view "$NAME@$VERSION" version > /dev/null 2>&1; then
+            echo "$NAME@$VERSION is already on npm. Nothing to release."
+            echo "publish=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "$NAME@$VERSION is not on npm. Releasing."
+            echo "publish=true" >> "$GITHUB_OUTPUT"
+          fi
+
+  release:
+    name: Publish v${{ needs.check.outputs.version }}
+    needs: check
+    if: needs.check.outputs.publish == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
 
     steps:
       - uses: actions/checkout@v5
@@ -35,6 +82,11 @@ jobs:
           node-version: 22
           registry-url: https://registry.npmjs.org
 
+      # Trusted publishing needs npm 11.5.1 or newer. The npm bundled with
+      # Node 22 predates it.
+      - name: Use an npm that supports trusted publishing
+        run: npm install --global npm@latest
+
       - name: Install dependencies
         run: bun install
 
@@ -47,17 +99,31 @@ jobs:
       - name: Build
         run: bun run build
 
-      - name: Check release tag matches package version
-        if: github.event_name == 'release'
-        run: |
-          PKG_VERSION="$(node -p "require('./package.json').version")"
-          TAG="${GITHUB_REF_NAME#v}"
-          if [ "$PKG_VERSION" != "$TAG" ]; then
-            echo "::error::Tag $GITHUB_REF_NAME does not match package.json version $PKG_VERSION"
-            exit 1
-          fi
-
-      - name: Publish
+      # Publishing comes before tagging on purpose: a failed publish should not
+      # leave a tag claiming a release that does not exist.
+      - name: Publish to npm
         run: npm publish --provenance --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Tag and create the GitHub Release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          VERSION: ${{ needs.check.outputs.version }}
+        run: |
+          git tag "v$VERSION"
+          git push origin "v$VERSION"
+
+          # Prefer the matching CHANGELOG section; fall back to generated notes
+          # when this version has no entry.
+          awk -v header="## [$VERSION]" '
+            index($0, header) == 1 { found = 1; next }
+            found && /^## / { exit }
+            found { print }
+          ' CHANGELOG.md > release-notes.md
+
+          if [ -s release-notes.md ] && grep -q '[^[:space:]]' release-notes.md; then
+            gh release create "v$VERSION" --title "v$VERSION" --notes-file release-notes.md
+          else
+            gh release create "v$VERSION" --title "v$VERSION" --generate-notes
+          fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   build, and package verification on every push and pull request.
 - Integration tests covering cache miss, `.apk` file caching, `.app` bundle
   caching, overwrite, and round-trip resolve.
-- Release workflow that publishes to npm with provenance from a GitHub Release.
+- Release workflow: bumping the version in `package.json` and merging to `main`
+  publishes to npm with provenance, pushes the `v<version>` tag, and opens a
+  GitHub Release from this file. Pushes that do not change the version are
+  skipped.
 - `CONTRIBUTING.md`, `CODE_OF_CONDUCT.md`, `SECURITY.md`, issue and pull request
   templates, and Dependabot configuration.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,57 @@
+# Changelog
+
+All notable changes to this project are documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+
+- MIT `LICENSE` file (the package was already declared MIT in `package.json`).
+- Continuous integration on Ubuntu and macOS: typecheck, integration tests,
+  build, and package verification on every push and pull request.
+- Integration tests covering cache miss, `.apk` file caching, `.app` bundle
+  caching, overwrite, and round-trip resolve.
+- Release workflow that publishes to npm with provenance from a GitHub Release.
+- `CONTRIBUTING.md`, `CODE_OF_CONDUCT.md`, `SECURITY.md`, issue and pull request
+  templates, and Dependabot configuration.
+
+### Changed
+
+- `@expo/config` is now an explicit devDependency instead of being picked up
+  transitively through `expo-module-scripts`.
+
+## [1.0.3] - 2025-10-09
+
+### Fixed
+
+- Corrected the documented cache directory path in the README.
+
+## [1.0.2] - 2025-09-02
+
+### Changed
+
+- Clarified installation instructions in the README.
+
+## [1.0.1] - 2025-09-02
+
+### Added
+
+- README documenting configuration, cache layout, and troubleshooting.
+
+## [1.0.0] - 2025-09-02
+
+### Added
+
+- Initial release: a `BuildCacheProviderPlugin` for Expo CLI that stores build
+  artifacts under `.expo/cache`, keyed by fingerprint hash and platform.
+  Handles iOS `.app` bundles as directories (via `ditto`, falling back to
+  `cp -R`) and Android `.apk` files as single files.
+
+[unreleased]: https://github.com/dennytosp/eas-local-cache/compare/v1.0.3...HEAD
+[1.0.3]: https://github.com/dennytosp/eas-local-cache/compare/v1.0.2...v1.0.3
+[1.0.2]: https://github.com/dennytosp/eas-local-cache/compare/v1.0.1...v1.0.2
+[1.0.1]: https://github.com/dennytosp/eas-local-cache/compare/v1.0.0...v1.0.1
+[1.0.0]: https://github.com/dennytosp/eas-local-cache/releases/tag/v1.0.0

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,125 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, caste, color, religion, or sexual
+identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+- Demonstrating empathy and kindness toward other people
+- Being respectful of differing opinions, viewpoints, and experiences
+- Giving and gracefully accepting constructive feedback
+- Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+- Focusing on what is best not just for us as individuals, but for the overall
+  community
+
+Examples of unacceptable behavior include:
+
+- The use of sexualized language or imagery, and sexual attention or advances of
+  any kind
+- Trolling, insulting or derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information, such as a physical or email address,
+  without their explicit permission
+- Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for moderation
+decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+Examples of representing our community include using an official email address,
+posting via an official social media account, or acting as an appointed
+representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the community leaders responsible for enforcement at
+**phong.dinh2108@gmail.com**. All complaints will be reviewed and investigated
+promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of
+actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. Violating
+these terms may lead to a temporary or permanent ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. Violating these
+terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior, harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the
+community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.1, available at
+https://www.contributor-covenant.org/version/2/1/code_of_conduct.html.
+
+Community Impact Guidelines were inspired by
+[Mozilla's code of conduct enforcement ladder][mozilla].
+
+[homepage]: https://www.contributor-covenant.org
+[mozilla]: https://github.com/mozilla/diversity
+
+For answers to common questions about this code of conduct, see the FAQ at
+https://www.contributor-covenant.org/faq. Translations are available at
+https://www.contributor-covenant.org/translations.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,122 @@
+# Contributing to eas-local-cache
+
+Thanks for your interest in improving the plugin. This document covers how to
+run it locally, what the checks are, and how releases work.
+
+By participating you agree to the [Code of Conduct](./CODE_OF_CONDUCT.md).
+
+## What this project is
+
+`eas-local-cache` implements Expo's `BuildCacheProviderPlugin` interface. Expo
+CLI calls two functions:
+
+- `resolveBuildCache` — given a fingerprint hash and platform, return the path
+  to a cached artifact or `null`.
+- `uploadBuildCache` — given a freshly built artifact, copy it into the cache
+  and return where it landed.
+
+Everything lives in a single file, `src/index.ts`. Artifacts are stored under
+`.expo/cache` in the project root as `ios_<hash>.app` (a directory) or
+`android_<hash>.apk` (a file).
+
+Fingerprint hashes are computed by Expo, not by this plugin. If two builds you
+expect to match produce different hashes, that is upstream behaviour — see
+[Expo's build cache documentation](https://docs.expo.dev/guides/cache-builds-remotely/).
+
+## Prerequisites
+
+- [Bun](https://bun.sh) 1.1 or newer
+- Node.js 20 or newer (used by `npm pack` / publishing)
+- macOS if you want to exercise the `ditto` copy path; Linux falls back to `cp -R`
+
+## Local setup
+
+```bash
+git clone https://github.com/dennytosp/eas-local-cache.git
+cd eas-local-cache
+bun install
+```
+
+## The checks
+
+These are exactly what CI runs on every pull request, on both Ubuntu and macOS:
+
+```bash
+bun run typecheck   # tsc --noEmit over src/ and test/
+bun test            # integration tests against a temporary project root
+bun run build       # tsc -> build/
+```
+
+### About the tests
+
+`test/plugin.test.ts` drives the real plugin against a real filesystem: it
+creates a temporary project root, `chdir`s into it *before* importing the module
+(the cache directory is resolved from `process.cwd()` at load time), then
+exercises cache misses, `.apk` file caching, `.app` bundle caching, overwrites,
+and full round trips.
+
+No mocking of `fs` — the tests would not catch a broken `ditto`/`cp` fallback
+otherwise, which is the part most likely to break across platforms.
+
+## Trying it in a real project
+
+The most useful manual test is a real Expo app:
+
+```bash
+cd eas-local-cache
+bun run build
+bun link
+
+cd ../your-expo-app
+bun link eas-local-cache
+```
+
+Then add the provider to `app.config.ts`:
+
+```typescript
+experiments: {
+  buildCacheProvider: {
+    plugin: 'eas-local-cache',
+  },
+}
+```
+
+Run `npx expo run:ios` twice. The second run should print `Cache hit!` and skip
+the build. `rm -rf .expo/cache` resets it.
+
+## Pull requests
+
+1. Branch off `main`, e.g. `fix/stale-ios-bundle`.
+2. Keep the change focused.
+3. Run the three checks above.
+4. Fill in the PR template, including what you verified end to end.
+5. Add an entry to [CHANGELOG.md](./CHANGELOG.md) under `Unreleased`.
+
+Commit messages use a gitmoji + short summary style
+(`:sparkles: Initialize | Expo builds local cache`), but this is not enforced.
+
+## Things to be careful about
+
+- **Cache correctness beats cache hits.** A wrong artifact reused is far worse
+  than a rebuild. When in doubt, return `null`.
+- **Never delete outside `.expo/cache`.** `uploadBuildCache` removes an existing
+  destination before copying; keep that strictly scoped to the cache directory.
+- **Keep the dependency list empty.** The plugin runs inside the user's build,
+  and today ships zero runtime dependencies. Node's stdlib should be enough.
+
+## Releasing
+
+Maintainers only.
+
+1. Update `CHANGELOG.md`, moving `Unreleased` entries under the new version.
+2. Bump the version in `package.json`.
+3. Merge to `main` and confirm CI is green.
+4. Create a GitHub Release with the tag `v<version>` (e.g. `v1.1.0`).
+5. The [Release workflow](./.github/workflows/release.yml) verifies the tag
+   matches `package.json`, re-runs the checks, and publishes to npm with
+   provenance.
+
+## Questions
+
+Open a [Discussion](https://github.com/dennytosp/eas-local-cache/discussions)
+for usage questions, and an issue for bugs.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -106,15 +106,31 @@ Commit messages use a gitmoji + short summary style
 
 ## Releasing
 
-Maintainers only.
+Maintainers only. Merging a version bump into `main` is what releases —
+there is no separate publish step to remember.
 
-1. Update `CHANGELOG.md`, moving `Unreleased` entries under the new version.
-2. Bump the version in `package.json`.
-3. Merge to `main` and confirm CI is green.
-4. Create a GitHub Release with the tag `v<version>` (e.g. `v1.1.0`).
-5. The [Release workflow](./.github/workflows/release.yml) verifies the tag
-   matches `package.json`, re-runs the checks, and publishes to npm with
-   provenance.
+1. In a pull request: move the `Unreleased` entries in `CHANGELOG.md` under the
+   new version, and bump `package.json`.
+
+   ```bash
+   npm version minor --no-git-tag-version   # or patch / major
+   ```
+
+   `--no-git-tag-version` matters: the tag is created by CI after a successful
+   publish, so it never points at a release that failed halfway.
+
+2. Merge the pull request.
+
+The [Release workflow](./.github/workflows/release.yml) then compares
+`package.json` against the registry. If that version is already on npm it stops;
+otherwise it re-runs typecheck, tests and build on Ubuntu, publishes with
+provenance, pushes the `v<version>` tag, and opens a GitHub Release using the
+matching `CHANGELOG.md` section.
+
+Choosing the version number stays a human decision — nothing infers semver from
+commit messages. The plugin's public surface is the `BuildCacheProviderPlugin`
+contract, so a change to what `resolveBuildCache` returns, or to the cache key
+layout, is breaking even though the file is small.
 
 ## Questions
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Phong Dinh (dennytosp)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,11 @@
 # EAS Local Cache
 
+[![CI](https://github.com/dennytosp/eas-local-cache/actions/workflows/ci.yml/badge.svg)](https://github.com/dennytosp/eas-local-cache/actions/workflows/ci.yml)
+[![npm version](https://img.shields.io/npm/v/eas-local-cache.svg)](https://www.npmjs.com/package/eas-local-cache)
+[![npm downloads](https://img.shields.io/npm/dm/eas-local-cache.svg)](https://www.npmjs.com/package/eas-local-cache)
+[![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](./LICENSE)
+[![PRs welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](./CONTRIBUTING.md)
+
 ## Introduction
 
 EAS Local Cache is a library designed to optimize build times by caching build artifacts locally. This allows subsequent builds with the same configuration to reuse previously built artifacts instead of rebuilding them from scratch.
@@ -75,8 +81,32 @@ If you're experiencing issues with cached builds:
 
 ## Contributing
 
-To contribute to this library:
+Contributions are welcome — bug reports, docs fixes, and cache-correctness fixes
+especially.
 
-1. Make changes to the implementation in `eas-local-cache`.
-2. Test with various build configurations.
-3. Submit pull requests with clear descriptions of changes and benefits.
+```bash
+git clone https://github.com/dennytosp/eas-local-cache.git
+cd eas-local-cache
+bun install
+
+bun run typecheck   # tsc --noEmit over src/ and test/
+bun test            # integration tests against a temporary project root
+bun run build       # tsc -> build/
+```
+
+These three commands are exactly what CI runs on every pull request, on both
+Ubuntu and macOS. See [CONTRIBUTING.md](./CONTRIBUTING.md) for the full guide
+(including how to link the plugin into a real Expo app), and
+[CODE_OF_CONDUCT.md](./CODE_OF_CONDUCT.md) for community expectations.
+
+- Found a bug? [Open an issue](https://github.com/dennytosp/eas-local-cache/issues/new?template=bug_report.yml)
+- Have a usage question? [Start a discussion](https://github.com/dennytosp/eas-local-cache/discussions)
+- Found a security problem? See [SECURITY.md](./SECURITY.md) — please do not open a public issue
+
+## Changelog
+
+See [CHANGELOG.md](./CHANGELOG.md).
+
+## License
+
+[MIT](./LICENSE) © Phong Dinh

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,51 @@
+# Security Policy
+
+## Supported versions
+
+Security fixes land on the latest published minor release. Older versions are
+not patched — please upgrade before reporting.
+
+| Version | Supported |
+| ------- | --------- |
+| 1.0.x   | Yes       |
+| < 1.0   | No        |
+
+## Reporting a vulnerability
+
+Please do **not** open a public issue for a security problem.
+
+Report it privately through GitHub's
+[private vulnerability reporting](https://github.com/dennytosp/eas-local-cache/security/advisories/new),
+or by email to **phong.dinh2108@gmail.com**.
+
+Please include:
+
+- The affected version of `eas-local-cache`
+- A description of the issue and its impact
+- Steps to reproduce
+
+### What to expect
+
+- **Acknowledgement** within 5 working days.
+- An assessment and a plan (fix, mitigation, or "not a vulnerability, and why")
+  within 14 days.
+- Credit in the release notes when the fix ships, unless you prefer otherwise.
+
+## Scope
+
+`eas-local-cache` is a development-time Expo CLI plugin. It runs on a
+developer's machine or CI runner during `expo run:ios` / `expo run:android`,
+reads and writes under `.expo/cache` in the project root, and shells out to
+`ditto` or `cp` to copy build artifacts. It ships no runtime dependencies and
+performs no network access.
+
+Reports that are in scope include:
+
+- Path traversal or writes outside the project's `.expo/cache` directory
+- Command injection through fingerprint hashes, platform names, or build paths
+- Cache poisoning: causing a build artifact to be reused for a configuration it
+  was not built for
+- Supply-chain issues with the published npm package or the release workflow
+
+Vulnerabilities in Expo CLI, `@expo/config`, or the fingerprinting itself should
+be reported to [Expo](https://github.com/expo/expo/security) directly.

--- a/package.json
+++ b/package.json
@@ -6,6 +6,9 @@
   "types": "build/index.d.ts",
   "scripts": {
     "build": "tsc",
+    "dev": "tsc --watch",
+    "typecheck": "tsc --noEmit -p tsconfig.test.json",
+    "test": "bun test",
     "prepack": "bun run build"
   },
   "repository": {
@@ -15,7 +18,11 @@
   "keywords": [
     "expo",
     "expo-cache",
-    "eas-cache"
+    "eas-cache",
+    "build-cache",
+    "buildCacheProvider",
+    "expo-cli",
+    "react-native"
   ],
   "author": "mad.dinh",
   "license": "MIT",
@@ -24,7 +31,22 @@
   },
   "homepage": "https://github.com/dennytosp/eas-local-cache#readme",
   "devDependencies": {
+    "@expo/config": "^57.0.7",
+    "@types/bun": "^1.3.14",
     "expo-module-scripts": "^4.1.10",
     "typescript": "^5.9.2"
+  },
+  "files": [
+    "build",
+    "src",
+    "README.md",
+    "CHANGELOG.md",
+    "LICENSE"
+  ],
+  "engines": {
+    "node": ">=18"
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }

--- a/test/plugin.test.ts
+++ b/test/plugin.test.ts
@@ -1,0 +1,193 @@
+import { afterAll, beforeEach, describe, expect, it } from "bun:test";
+import type {
+  ResolveBuildCacheProps,
+  UploadBuildCacheProps,
+} from "@expo/config";
+import * as fs from "fs";
+import * as os from "os";
+import * as path from "path";
+
+/**
+ * The plugin resolves its cache directory from `process.cwd()` at module load
+ * time, so we move into a throwaway project root *before* importing it.
+ */
+const originalCwd = process.cwd();
+// realpath: on macOS os.tmpdir() is the /var -> /private/var symlink, and the
+// plugin reports the resolved path, so comparisons would otherwise disagree.
+const projectRoot = fs.realpathSync(
+  fs.mkdtempSync(path.join(os.tmpdir(), "eas-local-cache-"))
+);
+process.chdir(projectRoot);
+
+const cacheDir = path.join(projectRoot, ".expo/cache");
+
+const mod = await import("../src/index");
+const plugin = mod.default;
+
+if (!("resolveBuildCache" in plugin) || !("uploadBuildCache" in plugin)) {
+  throw new Error("Plugin must implement resolveBuildCache/uploadBuildCache");
+}
+
+const { resolveBuildCache, uploadBuildCache } = plugin;
+
+afterAll(() => {
+  process.chdir(originalCwd);
+  fs.rmSync(projectRoot, { recursive: true, force: true });
+});
+
+beforeEach(() => {
+  fs.rmSync(cacheDir, { recursive: true, force: true });
+});
+
+const resolveProps = (
+  platform: "ios" | "android",
+  fingerprintHash: string
+): ResolveBuildCacheProps =>
+  ({ projectRoot, platform, fingerprintHash } as ResolveBuildCacheProps);
+
+const uploadProps = (
+  platform: "ios" | "android",
+  fingerprintHash: string,
+  buildPath: string
+): UploadBuildCacheProps =>
+  ({
+    projectRoot,
+    platform,
+    fingerprintHash,
+    buildPath,
+  } as UploadBuildCacheProps);
+
+/** Creates a fake .apk on disk and returns its path. */
+const makeApk = (name: string) => {
+  const apk = path.join(projectRoot, name);
+  fs.writeFileSync(apk, "not-really-an-apk");
+  return apk;
+};
+
+/** Creates a fake .app bundle (a directory) on disk and returns its path. */
+const makeAppBundle = (name: string) => {
+  const app = path.join(projectRoot, name);
+  fs.mkdirSync(path.join(app, "Contents"), { recursive: true });
+  fs.writeFileSync(path.join(app, "Contents", "Info.plist"), "<plist/>");
+  return app;
+};
+
+describe("resolveBuildCache", () => {
+  it("returns null when nothing has been cached", async () => {
+    const result = await resolveBuildCache(resolveProps("android", "abc123"), {});
+    expect(result).toBeNull();
+  });
+
+  it("creates the cache directory as a side effect of looking up", async () => {
+    await resolveBuildCache(resolveProps("android", "abc123"), {});
+    expect(fs.existsSync(cacheDir)).toBe(true);
+  });
+
+  it("does not match a different fingerprint", async () => {
+    await uploadBuildCache(
+      uploadProps("android", "hash-one", makeApk("one.apk")),
+      {}
+    );
+
+    const result = await resolveBuildCache(
+      resolveProps("android", "hash-two"),
+      {}
+    );
+    expect(result).toBeNull();
+  });
+
+  it("does not match the same fingerprint on a different platform", async () => {
+    await uploadBuildCache(
+      uploadProps("android", "shared-hash", makeApk("shared.apk")),
+      {}
+    );
+
+    const result = await resolveBuildCache(
+      resolveProps("ios", "shared-hash"),
+      {}
+    );
+    expect(result).toBeNull();
+  });
+
+  it("rejects an iOS cache entry that is a file rather than an .app bundle", async () => {
+    fs.mkdirSync(cacheDir, { recursive: true });
+    fs.writeFileSync(path.join(cacheDir, "ios_corrupt.app"), "not a bundle");
+
+    const result = await resolveBuildCache(resolveProps("ios", "corrupt"), {});
+    expect(result).toBeNull();
+  });
+});
+
+describe("uploadBuildCache", () => {
+  it("returns null when the build artifact does not exist", async () => {
+    const result = await uploadBuildCache(
+      uploadProps("android", "missing", path.join(projectRoot, "nope.apk")),
+      {}
+    );
+    expect(result).toBeNull();
+  });
+
+  it("caches an Android .apk file and names it by platform and fingerprint", async () => {
+    const cached = await uploadBuildCache(
+      uploadProps("android", "abc123", makeApk("app-release.apk")),
+      {}
+    );
+
+    expect(cached).toBe(path.join(cacheDir, "android_abc123.apk"));
+    expect(fs.readFileSync(cached!, "utf8")).toBe("not-really-an-apk");
+  });
+
+  it("caches an iOS .app bundle as a directory, contents included", async () => {
+    const cached = await uploadBuildCache(
+      uploadProps("ios", "abc123", makeAppBundle("MyApp.app")),
+      {}
+    );
+
+    expect(cached).toBe(path.join(cacheDir, "ios_abc123.app"));
+    expect(fs.statSync(cached!).isDirectory()).toBe(true);
+    expect(fs.existsSync(path.join(cached!, "Contents", "Info.plist"))).toBe(
+      true
+    );
+  });
+
+  it("overwrites a previously cached bundle for the same fingerprint", async () => {
+    const first = makeAppBundle("First.app");
+    await uploadBuildCache(uploadProps("ios", "same", first), {});
+
+    const second = makeAppBundle("Second.app");
+    fs.writeFileSync(path.join(second, "Contents", "marker"), "v2");
+    const cached = await uploadBuildCache(uploadProps("ios", "same", second), {});
+
+    expect(fs.existsSync(path.join(cached!, "Contents", "marker"))).toBe(true);
+  });
+});
+
+describe("round trip", () => {
+  it("a cached Android build is found again on the next resolve", async () => {
+    const uploaded = await uploadBuildCache(
+      uploadProps("android", "round-trip", makeApk("round-trip.apk")),
+      {}
+    );
+
+    const resolved = await resolveBuildCache(
+      resolveProps("android", "round-trip"),
+      {}
+    );
+
+    expect(resolved).toBe(uploaded);
+  });
+
+  it("a cached iOS build is found again on the next resolve", async () => {
+    const uploaded = await uploadBuildCache(
+      uploadProps("ios", "round-trip", makeAppBundle("RoundTrip.app")),
+      {}
+    );
+
+    const resolved = await resolveBuildCache(
+      resolveProps("ios", "round-trip"),
+      {}
+    );
+
+    expect(resolved).toBe(uploaded);
+  });
+});

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -1,0 +1,15 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "rootDir": ".",
+    // The tests are executed by Bun, not by tsc's Node16 CommonJS emit, so they
+    // type-check against bundler resolution (extensionless imports, top-level await).
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "target": "esnext",
+    "types": ["bun", "node"]
+  },
+  "include": ["src/**/*", "test/**/*"],
+  "exclude": ["node_modules", "build"]
+}


### PR DESCRIPTION
## Why

The repo was missing the basics that both consumers and program reviewers look for:

- `package.json` declared MIT, but there was **no `LICENSE` file** — GitHub and npm both showed the project as unlicensed, which technically means "all rights reserved" to anyone reading it.
- **No tests and no CI.** Nothing verified that a change still resolved or stored a cache entry correctly.
- No contributing guide, code of conduct, security policy, changelog, or issue templates.

## What changed

**Licensing**
- `LICENSE` — MIT, matching the existing `package.json` declaration.

**Tests** — 11 integration tests in `test/plugin.test.ts`. They drive the real exported plugin against a **real filesystem** in a temporary project root (the module resolves its cache dir from `process.cwd()` at load time, so the test `chdir`s before importing):

- cache miss returns `null`; the lookup creates `.expo/cache`
- a different fingerprint, or the same fingerprint on the other platform, does not match
- an iOS entry that is a plain file rather than an `.app` directory is rejected
- a missing build artifact returns `null` instead of caching garbage
- Android `.apk` caches as a file, iOS `.app` caches as a directory with contents intact
- re-uploading the same fingerprint overwrites the previous bundle
- upload → resolve round trips for both platforms

Nothing is mocked. Mocking `fs` would have hidden exactly the thing most likely to break: the `ditto` → `cp -R` fallback.

**CI** (`.github/workflows/ci.yml`) — runs `typecheck` → `bun test` → `build` → `npm pack` on **both `ubuntu-latest` and `macos-latest`**. That matters for this project specifically: `copyDirectory` prefers `ditto` (macOS only) and falls back to `cp -R`, so the matrix covers both branches.

**Type safety** — new `typecheck` script and `tsconfig.test.json` so `src/` *and* `test/` are type-checked. `@expo/config` is now an explicit devDependency rather than being hoisted in through `expo-module-scripts`. It is types-only — the compiled `build/index.js` requires nothing but `child_process`, `fs`, and `path`, so the package still ships **zero runtime dependencies**.

**Releases** (`.github/workflows/release.yml`) — merging a version bump into `main` is what publishes. The workflow compares `package.json` against the registry and stops if that version already exists, so ordinary commits never publish and the semver decision stays a human one made in the PR. After a successful publish it pushes the `v<version>` tag and opens a GitHub Release from the matching `CHANGELOG.md` section — that order means a tag can never point at a release that failed halfway.

Authentication is npm **trusted publishing** (OIDC): no token stored in the repository, nothing to rotate, and provenance is attested automatically. An `NPM_TOKEN` secret is still honoured as a fallback.

The "is this version already published?" check is deliberately not `npm view pkg@version` — that exits non-zero both when the version is unpublished *and* when the registry is unreachable, so a network blip would read as "not released yet" and trigger a publish. It fetches the version list once and separates the two: a 404 on the package name means never published and proceeds, anything else fails the run. `contents: write` and `id-token: write` are scoped to the publishing job only.

**Community docs** — `CONTRIBUTING.md` (including how to `bun link` the plugin into a real Expo app and what to be careful about: cache correctness over cache hits, never delete outside `.expo/cache`, keep dependencies at zero), `CODE_OF_CONDUCT.md`, `SECURITY.md` with a scope section written for a build-time plugin (path traversal, command injection, cache poisoning), `CHANGELOG.md` backfilled from git history, issue forms, PR template, Dependabot.

**Packaging** — explicit `files` list so the tarball ships `build/`, `src/`, README, CHANGELOG, and LICENSE; added `engines`, `publishConfig.access`, and more npm keywords.

## Verified locally

```
bun run typecheck   # clean
bun test            # 11 pass, 0 fail
bun run build       # clean
npm pack --dry-run  # 7 files, includes LICENSE + CHANGELOG
```

The release workflow's version check was exercised against the live registry across every branch it has:

| Input | Result |
| --- | --- |
| `eas-local-cache@1.0.3` | already published, skip |
| a version not on the registry | release |
| package that has never been published | release |
| package with a single version (registry returns a bare string, not an array) | handled |
| registry unreachable | hard fail, no publish |

The CHANGELOG note extraction was tested too, including that `1.0.1` does not swallow a hypothetical `1.0.10` section, and that a version with no CHANGELOG entry falls back to generated notes.

Not covered: the publishing job itself has never run — verifying it end to end would mean publishing. Its first real execution is the first version bump merged after this. The repo does not commit a lockfile, so CI resolves dependencies fresh on every run and is not reproducible.

## What happens when this merges

Two workflows fire on the merge commit:

- **CI** runs on Ubuntu and macOS as usual.
- **Release** runs too, because this PR touches `package.json`. Its `check` job should find `1.0.3` already on npm and skip the publishing job. That is the intended outcome and doubles as the first live test of the check logic. If the publishing job does *not* skip, something is wrong — stop and look before it reaches npm.

## Follow-up needed from the maintainer

**Configure the trusted publisher on npm** — this is the only step, and it is on npmjs.com rather than here: [package access settings](https://www.npmjs.com/package/eas-local-cache/access) → Trusted Publisher →

| Field | Value |
| --- | --- |
| Organization or user | `dennytosp` |
| Repository | `eas-local-cache` |
| Workflow filename | `release.yml` |
| Environment name | *(leave blank)* |

There is no secret to create.

Tags `v1.0.0`–`v1.0.3` and matching GitHub Releases have already been backfilled onto the published commits, so the CHANGELOG compare links resolve.

Discussions has been enabled, so the links in `.github/ISSUE_TEMPLATE/config.yml` and the README resolve.

A robustness bug found during review is filed separately rather than fixed here, since it relocates the cache directory for some setups: #2.
