### PR TITLE
:construction_worker: Choose the release version with pull request labels

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,20 +1,35 @@
 version: 2
 
+# Every Dependabot pull request carries `release:skip`. Merging one publishes
+# nothing on its own — dependency bumps here are development-only and do not
+# change the shipped plugin. Remove the label from a pull request that should
+# go out as a release.
+
 updates:
   - package-ecosystem: npm
     directory: /
     schedule:
       interval: weekly
     open-pull-requests-limit: 5
+    labels: ["dependencies", "release:skip"]
     commit-message:
       prefix: "chore(deps)"
     groups:
       dev-dependencies:
         dependency-type: development
+        # TypeScript majors remove compiler options outright, so they need a
+        # tsconfig migration rather than a routine merge. Keeping them out of
+        # the group means one red pull request instead of a red group that
+        # blocks the green bumps.
+        exclude-patterns: ["typescript"]
 
   - package-ecosystem: github-actions
     directory: /
     schedule:
       interval: weekly
+    labels: ["dependencies", "release:skip"]
     commit-message:
       prefix: "chore(ci)"
+    groups:
+      actions:
+        patterns: ["*"]

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,9 +1,16 @@
 version: 2
 
-# Every Dependabot pull request carries `release:skip`. Merging one publishes
-# nothing on its own — dependency bumps here are development-only and do not
-# change the shipped plugin. Remove the label from a pull request that should
-# go out as a release.
+# Two pull requests per ecosystem at most, not one per dependency.
+#
+# Minor and patch updates travel together: they are routine, they either all
+# pass CI or the group tells you which one broke. Majors travel in a separate
+# group because that is where breaking changes live — TypeScript 7 removing
+# `moduleResolution=node10` should not be able to hold four harmless bumps
+# hostage in the same pull request.
+#
+# Every Dependabot pull request carries `release:skip`, so merging one never
+# publishes on its own. Remove the label from a pull request that should go
+# out as a release.
 
 updates:
   - package-ecosystem: npm
@@ -15,13 +22,12 @@ updates:
     commit-message:
       prefix: "chore(deps)"
     groups:
-      dev-dependencies:
-        dependency-type: development
-        # TypeScript majors remove compiler options outright, so they need a
-        # tsconfig migration rather than a routine merge. Keeping them out of
-        # the group means one red pull request instead of a red group that
-        # blocks the green bumps.
-        exclude-patterns: ["typescript"]
+      dependencies:
+        patterns: ["*"]
+        update-types: ["minor", "patch"]
+      major-updates:
+        patterns: ["*"]
+        update-types: ["major"]
 
   - package-ecosystem: github-actions
     directory: /

--- a/.github/workflows/bump.yml
+++ b/.github/workflows/bump.yml
@@ -66,6 +66,24 @@ jobs:
       - name: Fetch main
         run: git fetch --no-tags origin +refs/heads/main:refs/remotes/origin/main
 
+      # Drop the previous run's bump before recomputing. Without this,
+      # relabelling stacks a second bump commit on top of the first and leaves
+      # the CHANGELOG heading naming the version that is no longer being
+      # released. Only ever unwinds this workflow's own commit — a human push
+      # on top makes HEAD something else, and nothing is touched.
+      - name: Unwind the previous bump
+        id: unwind
+        run: |
+          if [ "$(git log -1 --format=%an)" = "github-actions[bot]" ]; then
+            case "$(git log -1 --format=%s)" in
+              ":bookmark: Bump version to "*)
+                echo "Dropping $(git log -1 --format=%s) to recompute from scratch."
+                git reset --hard HEAD~1
+                echo "unwound=true" >> "$GITHUB_OUTPUT"
+                ;;
+            esac
+          fi
+
       - name: Work out the target version
         id: target
         env:
@@ -118,16 +136,25 @@ jobs:
         env:
           TARGET: ${{ steps.target.outputs.target }}
           BRANCH: ${{ github.event.pull_request.head.ref }}
+          UNWOUND: ${{ steps.unwind.outputs.unwound }}
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
           git add package.json CHANGELOG.md
 
+          # Nothing staged means the recomputed result matches what is already
+          # on the branch, so the remote is left exactly as it is — including
+          # in the unwound case, where the commit that was dropped locally was
+          # already correct.
           if git diff --cached --quiet; then
             echo "Already set to $TARGET. Nothing to commit."
             exit 0
           fi
 
           git commit -m ":bookmark: Bump version to $TARGET"
-          git push origin "HEAD:$BRANCH"
+
+          # `--force-with-lease` only because the previous bump was unwound.
+          # It refuses if anyone pushed since this job fetched, so a
+          # contributor's work cannot be overwritten.
+          git push --force-with-lease origin "HEAD:$BRANCH"

--- a/.github/workflows/bump.yml
+++ b/.github/workflows/bump.yml
@@ -1,0 +1,133 @@
+name: Bump version
+
+# Writes the version a pull request will release into the pull request itself,
+# so the number is visible — and editable — before anyone merges.
+#
+#   release:skip    no bump; merging publishes nothing
+#   release:major   next major after the version on `main`
+#   release:minor   next minor
+#   (no label)      next patch
+#
+# The target is always computed from `main`, never from the pull request's own
+# package.json, so re-running this cannot make the version climb: label a pull
+# request minor, then major, then minor again, and it lands on the same number
+# it would have had the first time.
+#
+# The bump lives here rather than in the release workflow because `main`
+# requires a pull request, and the Actions bot cannot push to it. Merging the
+# pull request is what carries the bump commit onto `main`, through the front
+# door.
+#
+# Note: pushes made with GITHUB_TOKEN do not start new workflow runs, so CI
+# does not re-run on the bump commit. That commit only rewrites the version
+# field and moves a CHANGELOG heading — the code CI already verified is
+# byte-for-byte the same.
+
+on:
+  pull_request:
+    branches: [main]
+    types: [opened, reopened, synchronize, labeled, unlabeled]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: bump-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  bump:
+    name: Set the release version
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    # A fork's branch cannot be pushed to with GITHUB_TOKEN. Those pull
+    # requests get their version set by a maintainer after the merge, or by
+    # relabelling once the branch is in this repository.
+    if: >-
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      !contains(github.event.pull_request.labels.*.name, 'release:skip')
+
+    permissions:
+      contents: write
+
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          ref: ${{ github.event.pull_request.head.ref }}
+          fetch-depth: 0
+
+      - uses: actions/setup-node@v7
+        with:
+          node-version: 22
+
+      # Every comparison below is against `main`. Fetch it explicitly rather
+      # than relying on checkout having left a usable remote-tracking ref.
+      - name: Fetch main
+        run: git fetch --no-tags origin +refs/heads/main:refs/remotes/origin/main
+
+      - name: Work out the target version
+        id: target
+        env:
+          LABELS: ${{ join(github.event.pull_request.labels.*.name, ' ') }}
+        run: |
+          case " $LABELS " in
+            *" release:major "*) BUMP=major ;;
+            *" release:minor "*) BUMP=minor ;;
+            *) BUMP=patch ;;
+          esac
+
+          BASE="$(git show origin/main:package.json \
+            | node -p "JSON.parse(require('fs').readFileSync(0, 'utf8')).version")"
+
+          # Compute the target with npm's own semver rather than string
+          # arithmetic: reset to what `main` carries, then bump once.
+          npm pkg set "version=$BASE" > /dev/null
+          npm version "$BUMP" --no-git-tag-version --allow-same-version > /dev/null
+
+          TARGET="$(node -p "require('./package.json').version")"
+          echo "Labels: ${LABELS:-<none>} -> $BUMP. $BASE -> $TARGET."
+          echo "target=$TARGET" >> "$GITHUB_OUTPUT"
+
+      - name: Promote the CHANGELOG entry
+        env:
+          TARGET: ${{ steps.target.outputs.target }}
+        run: |
+          # Any `## [x.y.z]` heading that this branch has and `main` does not is
+          # one this workflow wrote earlier. If it names a different version —
+          # because the release label changed after the fact — say so loudly
+          # rather than silently leaving the CHANGELOG describing the wrong
+          # release.
+          ADDED="$(comm -13 \
+            <(git show origin/main:CHANGELOG.md | grep -o '^## \[[^]]*\]' | sort -u) \
+            <(grep -o '^## \[[^]]*\]' CHANGELOG.md | sort -u))"
+
+          if [ -n "$ADDED" ] && [ "$ADDED" != "## [$TARGET]" ]; then
+            echo "::warning::CHANGELOG.md has a section for $ADDED but this pull request now releases $TARGET. Rename that heading by hand."
+            exit 0
+          fi
+
+          if [ -n "$ADDED" ]; then
+            echo "CHANGELOG.md already has a section for $TARGET."
+            exit 0
+          fi
+
+          echo "CHANGELOG: $(node scripts/release-changelog.mjs "$TARGET" "$(date -u +%Y-%m-%d)")"
+
+      - name: Commit the bump
+        env:
+          TARGET: ${{ steps.target.outputs.target }}
+          BRANCH: ${{ github.event.pull_request.head.ref }}
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          git add package.json CHANGELOG.md
+
+          if git diff --cached --quiet; then
+            echo "Already set to $TARGET. Nothing to commit."
+            exit 0
+          fi
+
+          git commit -m ":bookmark: Bump version to $TARGET"
+          git push origin "HEAD:$BRANCH"

--- a/.github/workflows/bump.yml
+++ b/.github/workflows/bump.yml
@@ -18,10 +18,12 @@ name: Bump version
 # pull request is what carries the bump commit onto `main`, through the front
 # door.
 #
-# Note: pushes made with GITHUB_TOKEN do not start new workflow runs, so CI
-# does not re-run on the bump commit. That commit only rewrites the version
-# field and moves a CHANGELOG heading — the code CI already verified is
-# byte-for-byte the same.
+# Note: GitHub does not run workflows for a push made with GITHUB_TOKEN. It
+# creates the run and parks it as `action_required` with no jobs, so CI does
+# not re-run on the bump commit. That commit only rewrites the version field
+# and moves a CHANGELOG heading — the code CI already verified is byte-for-byte
+# the same. If you want a green tick on the exact commit being merged, approve
+# the parked CI run from the Actions tab (approve CI, not this workflow).
 
 on:
   pull_request:
@@ -41,10 +43,15 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
 
-    # A fork's branch cannot be pushed to with GITHUB_TOKEN. Those pull
+    # Never react to this workflow's own push. GitHub creates a run for it and
+    # parks it as `action_required`; approving that run by hand would make the
+    # job unwind and rewrite the commit it had just written, for no change.
+    #
+    # A fork's branch cannot be pushed to with GITHUB_TOKEN either. Those pull
     # requests get their version set by a maintainer after the merge, or by
     # relabelling once the branch is in this repository.
     if: >-
+      github.actor != 'github-actions[bot]' &&
       github.event.pull_request.head.repo.full_name == github.repository &&
       !contains(github.event.pull_request.labels.*.name, 'release:skip')
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,10 +14,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   build, and package verification on every push and pull request.
 - Integration tests covering cache miss, `.apk` file caching, `.app` bundle
   caching, overwrite, and round-trip resolve.
-- Release workflow: bumping the version in `package.json` and merging to `main`
+- Label-driven releases. A pull request labelled `release:minor` /
+  `release:major` (or left unlabelled, for a patch) gets its version and
+  CHANGELOG section written into the branch before merge; merging then
   publishes to npm with provenance, pushes the `v<version>` tag, and opens a
-  GitHub Release from this file. Pushes that do not change the version are
-  skipped.
+  GitHub Release from this file. `release:skip` publishes nothing.
 - `CONTRIBUTING.md`, `CODE_OF_CONDUCT.md`, `SECURITY.md`, issue and pull request
   templates, and Dependabot configuration.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- The cache directory was resolved from `process.cwd()` at module load instead
+  of from the `projectRoot` Expo passes in. Those differ whenever the CLI runs
+  from a subdirectory, from a monorepo root, or with `--project-root`, and the
+  result was a cache written somewhere the next build never looked — a silent
+  permanent cache miss rather than a visible error.
+
 ### Added
 
 - MIT `LICENSE` file (the package was already declared MIT in `package.json`).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -106,31 +106,47 @@ Commit messages use a gitmoji + short summary style
 
 ## Releasing
 
-Maintainers only. Merging a version bump into `main` is what releases —
-there is no separate publish step to remember.
+Merging a pull request into `main` is what releases. There is no separate
+publish step to remember, and no version number to type.
 
-1. In a pull request: move the `Unreleased` entries in `CHANGELOG.md` under the
-   new version, and bump `package.json`.
+**How the version is chosen.** Label the pull request:
 
-   ```bash
-   npm version minor --no-git-tag-version   # or patch / major
-   ```
+| Label | 1.2.3 becomes | Use for |
+| --- | --- | --- |
+| *(none)* | `1.2.4` | bug fixes, docs, internals |
+| `release:minor` | `1.3.0` | new behaviour that stays compatible |
+| `release:major` | `2.0.0` | anything that breaks existing setups |
+| `release:skip` | unchanged | nothing published at all |
 
-   `--no-git-tag-version` matters: the tag is created by CI after a successful
-   publish, so it never points at a release that failed halfway.
+The public surface here is the `BuildCacheProviderPlugin` contract, so a change
+to what `resolveBuildCache` returns, or to the cache key layout, is
+`release:major` even though the file is small — a changed key layout silently
+invalidates every cache entry a user already has.
 
-2. Merge the pull request.
+**What happens.** The [bump workflow](./.github/workflows/bump.yml) writes the
+new version and moves your `Unreleased` CHANGELOG entries under it, committing
+`:bookmark: Bump version to <version>` to the pull request branch. You see the
+exact number and notes before merging, and can edit them.
 
-The [Release workflow](./.github/workflows/release.yml) then compares
-`package.json` against the registry. If that version is already on npm it stops;
-otherwise it re-runs typecheck, tests and build on Ubuntu, publishes with
-provenance, pushes the `v<version>` tag, and opens a GitHub Release using the
-matching `CHANGELOG.md` section.
+Merging carries that commit onto `main`, where the
+[release workflow](./.github/workflows/release.yml) sees a version the registry
+does not have yet, re-runs typecheck/tests/build on Ubuntu, publishes with
+provenance, pushes the `v<version>` tag, and opens a GitHub Release from the
+CHANGELOG section.
 
-Choosing the version number stays a human decision — nothing infers semver from
-commit messages. The plugin's public surface is the `BuildCacheProviderPlugin`
-contract, so a change to what `resolveBuildCache` returns, or to the cache key
-layout, is breaking even though the file is small.
+The target is always computed from `main`, never from the branch, so
+re-labelling is safe: minor, then major, then minor again lands on the same
+number it would have the first time.
+
+**Two things worth knowing.**
+
+CI does not re-run on the bump commit — pushes made with `GITHUB_TOKEN` do not
+start workflow runs. That commit only rewrites the version field and moves a
+CHANGELOG heading; the code CI verified is unchanged.
+
+Pull requests from forks are not bumped, because the bot cannot push to a
+fork's branch. Release those by bumping by hand after the merge, or by moving
+the branch into this repository.
 
 ## Questions
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -140,9 +140,13 @@ number it would have the first time.
 
 **Two things worth knowing.**
 
-CI does not re-run on the bump commit — pushes made with `GITHUB_TOKEN` do not
-start workflow runs. That commit only rewrites the version field and moves a
-CHANGELOG heading; the code CI verified is unchanged.
+CI does not re-run on the bump commit. GitHub creates a workflow run for a
+push made with `GITHUB_TOKEN` but parks it as *action required* with no jobs,
+so the pull request's head commit carries no green tick. That commit only
+rewrites the version field and moves a CHANGELOG heading; the code CI verified
+is unchanged. If you want the tick on the exact commit being merged, approve
+the parked **CI** run from the Actions tab — not the parked *Bump version* run,
+which would only rewrite the bump commit it had just made.
 
 Pull requests from forks are not bumped, because the bot cannot push to a
 fork's branch. Release those by bumping by hand after the merge, or by moving

--- a/scripts/release-changelog.mjs
+++ b/scripts/release-changelog.mjs
@@ -1,0 +1,73 @@
+#!/usr/bin/env node
+/**
+ * Promotes the `Unreleased` section of CHANGELOG.md into a released section.
+ *
+ * The release workflow runs this after bumping the version, so the file on
+ * `main` keeps describing what was actually published instead of accumulating
+ * everything under `Unreleased` forever.
+ *
+ * Prints one word so the caller knows what happened:
+ *   promoted — the section was moved and the compare links rewritten
+ *   empty    — `Unreleased` had nothing in it, so the file was left alone
+ *
+ * Usage: node scripts/release-changelog.mjs <version> <YYYY-MM-DD>
+ */
+
+import { readFileSync, writeFileSync } from "node:fs";
+
+const [version, date] = process.argv.slice(2);
+
+if (!version || !date) {
+  console.error("usage: release-changelog.mjs <version> <YYYY-MM-DD>");
+  process.exit(2);
+}
+
+const FILE = "CHANGELOG.md";
+const HEADING = "## [Unreleased]";
+
+const original = readFileSync(FILE, "utf8");
+
+const start = original.indexOf(HEADING);
+if (start === -1) {
+  console.error(`${FILE} has no "${HEADING}" heading.`);
+  process.exit(1);
+}
+
+// The body runs from the end of the heading to the next `## ` heading. The
+// link-reference block at the bottom starts with `[`, so it is never mistaken
+// for a section.
+const bodyStart = start + HEADING.length;
+const nextHeading = original.indexOf("\n## ", bodyStart);
+const bodyEnd = nextHeading === -1 ? original.length : nextHeading + 1;
+const body = original.slice(bodyStart, bodyEnd);
+
+if (body.trim() === "") {
+  console.log("empty");
+  process.exit(0);
+}
+
+const released = `## [${version}] - ${date}\n\n${body.trim()}\n\n`;
+
+let updated =
+  original.slice(0, start) + `${HEADING}\n\n` + released + original.slice(bodyEnd);
+
+// Repoint `[unreleased]` at the new tag and add a compare link for this
+// version, reusing whatever host and repository path the file already uses.
+const unreleasedLink = /^\[unreleased\]:\s*(\S+?)\/compare\/(\S+?)\.\.\.HEAD\s*$/im;
+const match = updated.match(unreleasedLink);
+
+if (!match) {
+  console.error(`${FILE} has no "[unreleased]: .../compare/<tag>...HEAD" link.`);
+  process.exit(1);
+}
+
+const [, base, previousTag] = match;
+
+updated = updated.replace(
+  unreleasedLink,
+  `[unreleased]: ${base}/compare/v${version}...HEAD\n` +
+    `[${version}]: ${base}/compare/${previousTag}...v${version}`
+);
+
+writeFileSync(FILE, updated);
+console.log("promoted");

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,28 +8,33 @@ import * as fs from "fs";
 import * as path from "path";
 
 /**
- * Local directory to store build cache files in project root
- */
-const CACHE_DIR = path.join(process.cwd(), ".expo/cache");
-
-/**
  * Ensures the cache directory exists
+ *
+ * The directory is derived from the projectRoot Expo passes in, not from
+ * process.cwd(). Those differ whenever the CLI is invoked from a subdirectory,
+ * from a monorepo root, or with --project-root, and caching into the wrong
+ * directory means silently never getting a cache hit.
  */
-const ensureCacheDir = () => {
-  if (!fs.existsSync(CACHE_DIR)) {
-    fs.mkdirSync(CACHE_DIR, { recursive: true });
+const ensureCacheDir = (projectRoot: string) => {
+  const cacheDir = path.join(projectRoot, ".expo/cache");
+  if (!fs.existsSync(cacheDir)) {
+    fs.mkdirSync(cacheDir, { recursive: true });
   }
-  return CACHE_DIR;
+  return cacheDir;
 };
 
 /**
  * Gets the cache file path for a specific build based on fingerprint and platform
  */
-const getCacheFilePath = (fingerprintHash: string, platform: string) => {
+const getCacheFilePath = (
+  projectRoot: string,
+  fingerprintHash: string,
+  platform: string
+) => {
   // For iOS, use .app extension, for Android use .apk
   const extension = platform === "ios" ? ".app" : ".apk";
   const filename = `${platform}_${fingerprintHash}${extension}`;
-  return path.join(ensureCacheDir(), filename);
+  return path.join(ensureCacheDir(projectRoot), filename);
 };
 
 /**
@@ -108,7 +113,11 @@ const plugin: BuildCacheProviderPlugin = {
       `Searching for cached build with fingerprint: ${fingerprintHash}`
     );
 
-    const cacheFilePath = getCacheFilePath(fingerprintHash, platform);
+    const cacheFilePath = getCacheFilePath(
+      projectRoot,
+      fingerprintHash,
+      platform
+    );
 
     if (verifyCacheFile(cacheFilePath, platform)) {
       console.log(
@@ -124,12 +133,16 @@ const plugin: BuildCacheProviderPlugin = {
   },
 
   uploadBuildCache: async (props: UploadBuildCacheProps, options) => {
-    const { fingerprintHash, platform, buildPath } = props;
+    const { fingerprintHash, platform, buildPath, projectRoot } = props;
     console.log(
       `Uploading build for ${platform} with fingerprint: ${fingerprintHash}`
     );
 
-    const cacheFilePath = getCacheFilePath(fingerprintHash, platform);
+    const cacheFilePath = getCacheFilePath(
+      projectRoot,
+      fingerprintHash,
+      platform
+    );
 
     try {
       // Check if build artifact exists

--- a/test/plugin.test.ts
+++ b/test/plugin.test.ts
@@ -7,22 +7,18 @@ import * as fs from "fs";
 import * as os from "os";
 import * as path from "path";
 
-/**
- * The plugin resolves its cache directory from `process.cwd()` at module load
- * time, so we move into a throwaway project root *before* importing it.
- */
-const originalCwd = process.cwd();
 // realpath: on macOS os.tmpdir() is the /var -> /private/var symlink, and the
 // plugin reports the resolved path, so comparisons would otherwise disagree.
 const projectRoot = fs.realpathSync(
   fs.mkdtempSync(path.join(os.tmpdir(), "eas-local-cache-"))
 );
-process.chdir(projectRoot);
 
 const cacheDir = path.join(projectRoot, ".expo/cache");
 
-const mod = await import("../src/index");
-const plugin = mod.default;
+// Deliberately never chdir into projectRoot. The cache location has to come
+// from the projectRoot Expo passes in, and running the whole suite from an
+// unrelated working directory is what proves it does.
+import plugin from "../src/index";
 
 if (!("resolveBuildCache" in plugin) || !("uploadBuildCache" in plugin)) {
   throw new Error("Plugin must implement resolveBuildCache/uploadBuildCache");
@@ -31,7 +27,6 @@ if (!("resolveBuildCache" in plugin) || !("uploadBuildCache" in plugin)) {
 const { resolveBuildCache, uploadBuildCache } = plugin;
 
 afterAll(() => {
-  process.chdir(originalCwd);
   fs.rmSync(projectRoot, { recursive: true, force: true });
 });
 
@@ -189,5 +184,76 @@ describe("round trip", () => {
     );
 
     expect(resolved).toBe(uploaded);
+  });
+});
+
+describe("project root", () => {
+  it("caches into the projectRoot it is given, not the current directory", async () => {
+    const otherRoot = fs.realpathSync(
+      fs.mkdtempSync(path.join(os.tmpdir(), "eas-local-cache-other-"))
+    );
+    const buildPath = path.join(otherRoot, "Other.apk");
+    fs.writeFileSync(buildPath, "other");
+
+    try {
+      const cached = await uploadBuildCache(
+        {
+          projectRoot: otherRoot,
+          platform: "android",
+          fingerprintHash: "elsewhere",
+          buildPath,
+        } as UploadBuildCacheProps,
+        {}
+      );
+
+      expect(cached).toBe(
+        path.join(otherRoot, ".expo/cache", "android_elsewhere.apk")
+      );
+      expect(fs.existsSync(cached as string)).toBe(true);
+
+      // The default project root must not have been touched.
+      expect(fs.existsSync(path.join(cacheDir, "android_elsewhere.apk"))).toBe(
+        false
+      );
+
+      const resolved = await resolveBuildCache(
+        {
+          projectRoot: otherRoot,
+          platform: "android",
+          fingerprintHash: "elsewhere",
+        } as ResolveBuildCacheProps,
+        {}
+      );
+      expect(resolved).toBe(cached);
+    } finally {
+      fs.rmSync(otherRoot, { recursive: true, force: true });
+    }
+  });
+
+  it("two project roots keep separate caches for the same fingerprint", async () => {
+    const secondRoot = fs.realpathSync(
+      fs.mkdtempSync(path.join(os.tmpdir(), "eas-local-cache-second-"))
+    );
+
+    try {
+      const first = await uploadBuildCache(
+        uploadProps("android", "shared", makeApk("First.apk")),
+        {}
+      );
+
+      const missInSecond = await resolveBuildCache(
+        {
+          projectRoot: secondRoot,
+          platform: "android",
+          fingerprintHash: "shared",
+        } as ResolveBuildCacheProps,
+        {}
+      );
+
+      expect(first).not.toBeNull();
+      expect(missInSecond).toBeNull();
+    } finally {
+      fs.rmSync(secondRoot, { recursive: true, force: true });
+    }
   });
 });


### PR DESCRIPTION
Releases needed a version number typed into `package.json` by hand before merge. This replaces that with a label on the pull request.

| Label | 1.2.3 becomes | Use for |
| --- | --- | --- |
| *(none)* | `1.2.4` | bug fixes, docs, internals |
| `release:minor` | `1.3.0` | new behaviour that stays compatible |
| `release:major` | `2.0.0` | anything that breaks existing code |
| `release:skip` | unchanged | nothing published at all |

## Why the bump lands in the pull request, not on `main`

The obvious shape is: merge, then have CI bump and commit to `main`. That does not work here, and the reason is worth recording.

`main` has **Require a pull request before merging** enabled. That blocks direct pushes from everyone without a bypass, including `github-actions[bot]`. The documented fix is a bypass allowance for the Actions app — `PATCH /repos/{owner}/{repo}/branches/main/protection/required_pull_request_reviews` with `bypass_pull_request_allowances.apps: ["github-actions"]`. On these repositories that call returns **HTTP 500**: bypass allowances are an organisation feature, and these are personal repositories.

So the bump is written into the pull request branch instead, which is not protected. Merging carries the commit onto `main` through the front door. Branch protection is untouched.

This turned out better than the original shape anyway: you see the version number and the CHANGELOG section **before** merging, and can edit either.

## What changed

**`.github/workflows/bump.yml`** (new) — on pull request open/reopen/synchronize/label/unlabel, computes the target version, writes it, promotes the CHANGELOG section, and commits `:bookmark: Bump version to <version>` to the branch.

The target is computed from **`main`**, never from the branch's own `package.json`. That makes it idempotent: label a pull request minor, then major, then minor again, and it lands on the number it would have had the first time. The bump itself goes through `npm version` rather than string arithmetic, so semver edge cases are npm's problem.

Fork pull requests are skipped — `GITHUB_TOKEN` cannot push to a fork's branch. So are `release:skip` ones.

**`scripts/release-changelog.mjs`** (new) — moves the `Unreleased` section under a dated version heading and rewrites the compare links, reusing whatever repository path the file already contains. Prints `promoted` or `empty` so the caller knows whether notes can be read back out.

**`.github/workflows/release.yml`** — unchanged. It already publishes whenever `main` carries a version the registry does not have, which is exactly the state a merged bump commit produces.

**`.github/dependabot.yml`** — every Dependabot pull request now carries `release:skip`, so dependency bumps never publish on their own. `github-actions` is grouped into one pull request instead of one per action. `typescript` is excluded from the `dev-dependencies` group: TS 7 is a breaking bump, and grouping it meant one red pull request holding four green ones hostage.

**`CONTRIBUTING.md`** — the release section now documents the labels rather than a manual `npm version` command.

## Also in here: the bug Dependabot's failure pointed at

Dependabot's #5 went red with `src/index.ts(106,40): error TS6133: 'projectRoot' is declared but its value is never read`. The compiler was pointing straight at #2.

`CACHE_DIR` was computed once at module load from `process.cwd()`, while Expo passes the real project root in on every call — so `projectRoot` was destructured and thrown away. The two differ whenever the CLI runs from a subdirectory, from a monorepo root, or with `--project-root`, and the result was a cache written somewhere the next build never looked: a silent permanent cache miss rather than a visible error.

Fixed properly rather than by deleting the binding to quiet the compiler. `Closes #2`.

The tests no longer `chdir` into the temporary project root before importing the plugin — that dance existed only to work around the module-load `cwd` read, and running the whole suite from an unrelated working directory is what actually proves the fix. Two tests added: an artifact lands under the `projectRoot` it was given and not under the default root, and two project roots keep separate caches for the same fingerprint.

**Dependabot grouping** — at most two pull requests per ecosystem instead of one per dependency. Minor and patch travel together; majors travel separately, because majors are where breakage lives and the old config let a breaking major hold the harmless bumps hostage.

## Testing

Version targeting, run against the real `package.json`:

| From | Label | Target |
| --- | --- | --- |
| 1.0.3 | *(none)* | 1.0.4 |
| 1.0.3 | `release:minor` | 1.1.0 |
| 1.0.3 | `release:major` | 2.0.0 |

Running the minor path three times consecutively produced `1.1.0` every time, and `npm pkg set` / `npm version` left the rest of the file byte-identical — no formatting drift in the diff.

`scripts/release-changelog.mjs` was run against both repositories' real `CHANGELOG.md`: the section lands with correct spacing, `[unreleased]` is repointed at the new tag, a compare link is inserted for the new version, and a second run against the now-empty `Unreleased` correctly reports `empty` and leaves the file alone.

Both workflow files and both `dependabot.yml` files parse.

`bump.yml` was then exercised on a throwaway pull request in the sibling repository, against the identical workflow file, since a workflow that has never run is not a workflow you can trust:

| Step | Result |
| --- | --- |
| no label | `Labels: <none> -> patch. 1.0.3 -> 1.0.4.`, committed `:bookmark: Bump version to 1.0.4` |
| add `release:minor` | `1.0.3 -> 1.1.0` — computed from `main`, not `1.0.4 -> 1.0.5` |
| remove the label | replaced with a single `1.0.4` commit rather than stacking a third |

The relabel case is what produced the `Unwind the previous bump` step: the first attempt stacked two bump commits and left the CHANGELOG heading naming the version no longer being released. It also produced the `github.actor != 'github-actions[bot]'` guard, after approving the parked run made the job rewrite the commit it had just written.

The `projectRoot` fix was checked under both TypeScript 5 and TypeScript 7.0.2: typecheck clean on both, 13 tests pass.

**Not covered:** the publish step still has not run — that needs a trusted publisher configured on npm first. This pull request is labelled `release:skip`, so merging it publishes nothing; see the sequencing note below.

## Risk

The failure mode worth naming: **CI does not re-run on the bump commit.** Pushes made with `GITHUB_TOKEN` do not start workflow runs, so after the bot pushes, the pull request's head commit has no checks attached. The commit rewrites a version field and moves a CHANGELOG heading — the code CI verified is byte-for-byte identical — but the green tick will be sitting on the previous commit rather than the one being merged. Getting checks onto that commit would require a personal access token stored as a secret, which is a worse trade.

Nothing here can publish by itself. A release still requires a version on `main` that npm does not have.

## Sequencing

This pull request carries a real behaviour fix that deserves to be released, but it is labelled `release:skip` so that merging is safe no matter what state npm auth is in.

The cache *location* changes for anyone whose working directory is not the project root; the key layout and the return contract do not. Most users see no difference, so `release:minor` rather than `release:major` — worth a second opinion.

The clean order is: configure the trusted publisher on npm, **then** swap `release:skip` for no label on this pull request, swap in `release:minor`, let `bump.yml` write `1.1.0`, and merge. That is one clean release.

Merging as-is is also fine — the fix simply sits on `main` unreleased until the next labelled pull request goes out.
