### PR TITLE
ci: prepare releases after merge

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -18,6 +18,15 @@
 
 <!-- iOS or Android, Expo SDK version, macOS or Linux. -->
 
+## Release decision
+
+<!-- Select exactly one. See RELEASING.md for the label commands. -->
+
+- [ ] Patch — no `release:*` label
+- [ ] Minor — `release:minor`
+- [ ] Major — `release:major`
+- [ ] Skip npm release — `release:skip`
+
 ## Notes for reviewers
 
 <!-- Anything about cache invalidation, on-disk layout, or platform-specific

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,9 +8,8 @@ version: 2
 # `moduleResolution=node10` should not be able to hold four harmless bumps
 # hostage in the same pull request.
 #
-# Every Dependabot pull request carries `release:skip`, so merging one never
-# publishes on its own. Remove the label from a pull request that should go
-# out as a release.
+# Dependabot pull requests use the default patch release when they pass CI.
+# Add `release:skip` manually only when a dependency update must not publish.
 
 updates:
   - package-ecosystem: npm
@@ -18,7 +17,7 @@ updates:
     schedule:
       interval: weekly
     open-pull-requests-limit: 5
-    labels: ["dependencies", "release:skip"]
+    labels: ["dependencies"]
     commit-message:
       prefix: "chore(deps)"
     groups:
@@ -33,7 +32,7 @@ updates:
     directory: /
     schedule:
       interval: weekly
-    labels: ["dependencies", "release:skip"]
+    labels: ["dependencies"]
     commit-message:
       prefix: "chore(ci)"
     groups:

--- a/.github/workflows/bump.yml
+++ b/.github/workflows/bump.yml
@@ -1,167 +1,137 @@
-name: Bump version
+name: Prepare release
 
-# Writes the version a pull request will release into the pull request itself,
-# so the number is visible — and editable — before anyone merges.
-#
-#   release:skip    no bump; merging publishes nothing
-#   release:major   next major after the version on `main`
-#   release:minor   next minor
-#   (no label)      next patch
-#
-# The target is always computed from `main`, never from the pull request's own
-# package.json, so re-running this cannot make the version climb: label a pull
-# request minor, then major, then minor again, and it lands on the same number
-# it would have had the first time.
-#
-# The bump lives here rather than in the release workflow because `main`
-# requires a pull request, and the Actions bot cannot push to it. Merging the
-# pull request is what carries the bump commit onto `main`, through the front
-# door.
-#
-# Note: GitHub does not run workflows for a push made with GITHUB_TOKEN. It
-# creates the run and parks it as `action_required` with no jobs, so CI does
-# not re-run on the bump commit. That commit only rewrites the version field
-# and moves a CHANGELOG heading — the code CI already verified is byte-for-byte
-# the same. If you want a green tick on the exact commit being merged, approve
-# the parked CI run from the Actions tab (approve CI, not this workflow).
+# Source pull requests never receive version commits. After a pull request is
+# merged, this workflow aggregates every merged change since the latest v* tag
+# and creates or refreshes one protected-path release pull request.
 
 on:
-  pull_request:
+  pull_request_target:
     branches: [main]
-    types: [opened, reopened, synchronize, labeled, unlabeled]
+    types: [closed]
+  workflow_dispatch:
 
 permissions:
   contents: read
 
 concurrency:
-  group: bump-${{ github.event.pull_request.number }}
-  cancel-in-progress: true
+  group: prepare-release
+  cancel-in-progress: false
 
 jobs:
-  bump:
-    name: Set the release version
+  prepare:
+    name: Create or update release PR
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      (github.event.pull_request.merged == true &&
+       github.event.pull_request.head.ref != 'release/next' &&
+       !contains(github.event.pull_request.labels.*.name, 'release:skip'))
     runs-on: ubuntu-latest
     timeout-minutes: 10
 
-    # Never react to this workflow's own push. GitHub creates a run for it and
-    # parks it as `action_required`; approving that run by hand would make the
-    # job unwind and rewrite the commit it had just written, for no change.
-    #
-    # A fork's branch cannot be pushed to with GITHUB_TOKEN either. Those pull
-    # requests get their version set by a maintainer after the merge, or by
-    # relabelling once the branch is in this repository.
-    if: >-
-      github.actor != 'github-actions[bot]' &&
-      github.event.pull_request.head.repo.full_name == github.repository &&
-      !contains(github.event.pull_request.labels.*.name, 'release:skip')
-
     permissions:
+      actions: write
       contents: write
+      pull-requests: write
 
     steps:
+      # pull_request_target has a write-capable token. Only trusted code from
+      # main is checked out; the merged pull request's head is never executed.
       - uses: actions/checkout@v7
         with:
-          ref: ${{ github.event.pull_request.head.ref }}
+          ref: main
           fetch-depth: 0
 
       - uses: actions/setup-node@v7
         with:
           node-version: 22
 
-      # Every comparison below is against `main`. Fetch it explicitly rather
-      # than relying on checkout having left a usable remote-tracking ref.
-      - name: Fetch main
-        run: git fetch --no-tags origin +refs/heads/main:refs/remotes/origin/main
-
-      # Drop the previous run's bump before recomputing. Without this,
-      # relabelling stacks a second bump commit on top of the first and leaves
-      # the CHANGELOG heading naming the version that is no longer being
-      # released. Only ever unwinds this workflow's own commit — a human push
-      # on top makes HEAD something else, and nothing is touched.
-      - name: Unwind the previous bump
-        id: unwind
+      - name: Verify the release baseline
+        id: baseline
         run: |
-          if [ "$(git log -1 --format=%an)" = "github-actions[bot]" ]; then
-            case "$(git log -1 --format=%s)" in
-              ":bookmark: Bump version to "*)
-                echo "Dropping $(git log -1 --format=%s) to recompute from scratch."
-                git reset --hard HEAD~1
-                echo "unwound=true" >> "$GITHUB_OUTPUT"
-                ;;
-            esac
+          BASE_TAG="$(git describe --tags --abbrev=0 --match 'v[0-9]*')"
+          TAG_VERSION="${BASE_TAG#v}"
+          MAIN_VERSION="$(node -p "require('./package.json').version")"
+
+          if [ "$MAIN_VERSION" != "$TAG_VERSION" ]; then
+            echo "::error::main is version $MAIN_VERSION but the latest tag is $BASE_TAG. Finish or repair that release before preparing another one."
+            exit 1
           fi
 
-      - name: Work out the target version
-        id: target
+          echo "base_tag=$BASE_TAG" >> "$GITHUB_OUTPUT"
+          echo "main_version=$MAIN_VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Collect merged release decisions
+        id: decision
         env:
-          LABELS: ${{ join(github.event.pull_request.labels.*.name, ' ') }}
+          GITHUB_TOKEN: ${{ github.token }}
+          RELEASE_BASE_BRANCH: main
+          RELEASE_BASE_TAG: ${{ steps.baseline.outputs.base_tag }}
+        run: node scripts/collect-release-decision.mjs
+
+      - name: Build the release commit
+        id: release
+        if: steps.decision.outputs.bump != 'skip'
+        env:
+          BUMP: ${{ steps.decision.outputs.bump }}
         run: |
-          case " $LABELS " in
-            *" release:major "*) BUMP=major ;;
-            *" release:minor "*) BUMP=minor ;;
-            *) BUMP=patch ;;
-          esac
+          OLD_SHA="$(git ls-remote origin refs/heads/release/next | awk '{print $1}')"
 
-          BASE="$(git show origin/main:package.json \
-            | node -p "JSON.parse(require('fs').readFileSync(0, 'utf8')).version")"
+          git fetch --no-tags origin +refs/heads/main:refs/remotes/origin/main
+          git switch -C release/next origin/main
 
-          # Compute the target with npm's own semver rather than string
-          # arithmetic: reset to what `main` carries, then bump once.
-          npm pkg set "version=$BASE" > /dev/null
           npm version "$BUMP" --no-git-tag-version --allow-same-version > /dev/null
-
           TARGET="$(node -p "require('./package.json').version")"
-          echo "Labels: ${LABELS:-<none>} -> $BUMP. $BASE -> $TARGET."
-          echo "target=$TARGET" >> "$GITHUB_OUTPUT"
-
-      - name: Promote the CHANGELOG entry
-        env:
-          TARGET: ${{ steps.target.outputs.target }}
-        run: |
-          # Any `## [x.y.z]` heading that this branch has and `main` does not is
-          # one this workflow wrote earlier. If it names a different version —
-          # because the release label changed after the fact — say so loudly
-          # rather than silently leaving the CHANGELOG describing the wrong
-          # release.
-          ADDED="$(comm -13 \
-            <(git show origin/main:CHANGELOG.md | grep -o '^## \[[^]]*\]' | sort -u) \
-            <(grep -o '^## \[[^]]*\]' CHANGELOG.md | sort -u))"
-
-          if [ -n "$ADDED" ] && [ "$ADDED" != "## [$TARGET]" ]; then
-            echo "::warning::CHANGELOG.md has a section for $ADDED but this pull request now releases $TARGET. Rename that heading by hand."
-            exit 0
-          fi
-
-          if [ -n "$ADDED" ]; then
-            echo "CHANGELOG.md already has a section for $TARGET."
-            exit 0
-          fi
-
           echo "CHANGELOG: $(node scripts/release-changelog.mjs "$TARGET" "$(date -u +%Y-%m-%d)")"
 
-      - name: Commit the bump
-        env:
-          TARGET: ${{ steps.target.outputs.target }}
-          BRANCH: ${{ github.event.pull_request.head.ref }}
-          UNWOUND: ${{ steps.unwind.outputs.unwound }}
-        run: |
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-
           git add package.json CHANGELOG.md
+          git commit -m "chore(release): v$TARGET"
 
-          # Nothing staged means the recomputed result matches what is already
-          # on the branch, so the remote is left exactly as it is — including
-          # in the unwound case, where the commit that was dropped locally was
-          # already correct.
-          if git diff --cached --quiet; then
-            echo "Already set to $TARGET. Nothing to commit."
-            exit 0
+          if [ -n "$OLD_SHA" ]; then
+            git push --force-with-lease="refs/heads/release/next:$OLD_SHA" origin HEAD:release/next
+          else
+            git push origin HEAD:release/next
           fi
 
-          git commit -m ":bookmark: Bump version to $TARGET"
+          echo "target=$TARGET" >> "$GITHUB_OUTPUT"
 
-          # `--force-with-lease` only because the previous bump was unwound.
-          # It refuses if anyone pushed since this job fetched, so a
-          # contributor's work cannot be overwritten.
-          git push --force-with-lease origin "HEAD:$BRANCH"
+      - name: Open or refresh the release PR
+        if: steps.decision.outputs.bump != 'skip'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          SOURCES: ${{ steps.decision.outputs.sources }}
+          TARGET: ${{ steps.release.outputs.target }}
+        run: |
+          BODY="$RUNNER_TEMP/release-pr.md"
+          {
+            echo "Releases the merged changes below as **v$TARGET**."
+            echo
+            echo "## Included changes"
+            echo
+            printf '%s\n' "$SOURCES"
+            echo
+            echo "## Merge behavior"
+            echo
+            echo "Merging this pull request puts the version and CHANGELOG update on \`main\`. The Release workflow then verifies, publishes to npm, tags \`v$TARGET\`, and creates the GitHub Release."
+          } > "$BODY"
+
+          PR_NUMBER="$(gh pr list --state open --base main --head release/next --json number --jq '.[0].number // empty')"
+
+          if [ -z "$PR_NUMBER" ]; then
+            gh pr create \
+              --base main \
+              --head release/next \
+              --title "chore(release): v$TARGET" \
+              --body-file "$BODY" \
+              --label "release:skip"
+          else
+            gh pr edit "$PR_NUMBER" \
+              --title "chore(release): v$TARGET" \
+              --body-file "$BODY" \
+              --add-label "release:skip"
+          fi
+
+          # Pushes and pull requests created by GITHUB_TOKEN do not trigger
+          # ordinary workflows, so dispatch CI explicitly on the release SHA.
+          gh workflow run ci.yml --ref release/next

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,11 +2,11 @@ name: Release
 
 # Publishes to npm when the version in package.json changes on `main`.
 #
-# The semver decision stays human: bump `package.json` in a pull request.
-# Merging that pull request is what releases. Everything after the merge —
+# Source pull request labels select semver after merge. The Prepare release
+# workflow puts that version in the dedicated `release/next` pull request.
+# Merging `release/next` is what releases. Everything after that merge —
 # publish, tag, GitHub Release — happens here. Pushes that do not change the
-# version are compared against the registry and skipped, so ordinary commits
-# never publish.
+# version are compared against the registry and skipped.
 #
 # Authentication uses npm trusted publishing (OIDC). There is no token to
 # store or rotate. Configure it once, at

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -106,51 +106,13 @@ Commit messages use a gitmoji + short summary style
 
 ## Releasing
 
-Merging a pull request into `main` is what releases. There is no separate
-publish step to remember, and no version number to type.
+Source pull requests never bump their own version. After a merge into `main`,
+the default decision is patch when no `release:*` label is present; use
+`release:minor`, `release:major`, or `release:skip` to override it. Automation
+then prepares a separate `release/next` pull request whose merge publishes.
 
-**How the version is chosen.** Label the pull request:
-
-| Label | 1.2.3 becomes | Use for |
-| --- | --- | --- |
-| *(none)* | `1.2.4` | bug fixes, docs, internals |
-| `release:minor` | `1.3.0` | new behaviour that stays compatible |
-| `release:major` | `2.0.0` | anything that breaks existing setups |
-| `release:skip` | unchanged | nothing published at all |
-
-The public surface here is the `BuildCacheProviderPlugin` contract, so a change
-to what `resolveBuildCache` returns, or to the cache key layout, is
-`release:major` even though the file is small — a changed key layout silently
-invalidates every cache entry a user already has.
-
-**What happens.** The [bump workflow](./.github/workflows/bump.yml) writes the
-new version and moves your `Unreleased` CHANGELOG entries under it, committing
-`:bookmark: Bump version to <version>` to the pull request branch. You see the
-exact number and notes before merging, and can edit them.
-
-Merging carries that commit onto `main`, where the
-[release workflow](./.github/workflows/release.yml) sees a version the registry
-does not have yet, re-runs typecheck/tests/build on Ubuntu, publishes with
-provenance, pushes the `v<version>` tag, and opens a GitHub Release from the
-CHANGELOG section.
-
-The target is always computed from `main`, never from the branch, so
-re-labelling is safe: minor, then major, then minor again lands on the same
-number it would have the first time.
-
-**Two things worth knowing.**
-
-CI does not re-run on the bump commit. GitHub creates a workflow run for a
-push made with `GITHUB_TOKEN` but parks it as *action required* with no jobs,
-so the pull request's head commit carries no green tick. That commit only
-rewrites the version field and moves a CHANGELOG heading; the code CI verified
-is unchanged. If you want the tick on the exact commit being merged, approve
-the parked **CI** run from the Actions tab — not the parked *Bump version* run,
-which would only rewrite the bump commit it had just made.
-
-Pull requests from forks are not bumped, because the bot cannot push to a
-fork's branch. Release those by bumping by hand after the merge, or by moving
-the branch into this repository.
+Read [RELEASING.md](./RELEASING.md) for the complete rules and copy-pasteable
+`gh` commands for creating, applying, changing, and verifying release labels.
 
 ## Questions
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,145 @@
+# Releasing
+
+Releases are selected with pull request labels. Pull request titles and commit
+messages do not determine the version.
+
+## Release decisions
+
+Choose exactly one release decision for every source pull request targeting
+`main`:
+
+| Decision | Pull request label | `1.2.3` becomes | Use for |
+| --- | --- | --- | --- |
+| Patch | No `release:*` label | `1.2.4` | Backwards-compatible fixes and small internal changes |
+| Minor | `release:minor` | `1.3.0` | Backwards-compatible provider behavior or options |
+| Major | `release:major` | `2.0.0` | Breaking cache-provider contract or behavior changes |
+| Skip | `release:skip` | Unchanged | Changes that must not publish a new npm version |
+
+Patch is the default. There is intentionally no `release:patch` label.
+
+Only one `release:*` label should be present. `release:skip` excludes the
+merged pull request from the next release, and `release:major` takes precedence
+over `release:minor` if conflicting labels are accidentally applied.
+
+## One-time label setup
+
+Run these commands once from the repository checkout. `--force` also repairs
+the description or color if the label already exists.
+
+```bash
+gh auth status
+
+gh label create "release:minor" \
+  --color "1D76DB" \
+  --description "Publish the next minor version after merge" \
+  --force
+
+gh label create "release:major" \
+  --color "B60205" \
+  --description "Publish the next major version after merge" \
+  --force
+
+gh label create "release:skip" \
+  --color "6A737D" \
+  --description "Do not publish a new npm version after merge" \
+  --force
+```
+
+If `gh auth status` reports an expired or missing login, run `gh auth login`
+before creating or editing labels.
+
+## Apply a decision to a pull request
+
+Set the pull request number once:
+
+```bash
+PR_NUMBER=123
+```
+
+### Patch
+
+Patch is represented by removing every release label:
+
+```bash
+gh pr edit "$PR_NUMBER" \
+  --remove-label "release:minor,release:major,release:skip"
+```
+
+### Minor
+
+```bash
+gh pr edit "$PR_NUMBER" \
+  --remove-label "release:major,release:skip" \
+  --add-label "release:minor"
+```
+
+### Major
+
+```bash
+gh pr edit "$PR_NUMBER" \
+  --remove-label "release:minor,release:skip" \
+  --add-label "release:major"
+```
+
+### Skip
+
+```bash
+gh pr edit "$PR_NUMBER" \
+  --remove-label "release:minor,release:major" \
+  --add-label "release:skip"
+```
+
+You can use a pull request URL or branch name instead of its number. When the
+current branch already has a pull request, `gh pr edit` also works without an
+argument.
+
+## Verify the decision
+
+List only the release labels currently applied to the pull request:
+
+```bash
+gh pr view "$PR_NUMBER" \
+  --json labels \
+  --jq '[.labels[].name | select(startswith("release:"))]'
+```
+
+Interpret the output as follows:
+
+- `[]` means patch.
+- `["release:minor"]` means minor.
+- `["release:major"]` means major.
+- `["release:skip"]` means no npm release.
+- More than one value is a conflict; apply one of the commands above again.
+
+## What automation does
+
+Source pull requests run CI without changing `package.json` or `CHANGELOG.md`.
+The release decision is read only after a pull request has been merged into
+`main`.
+
+After a non-skipped merge, the Prepare release workflow examines every merged
+change since the latest `v*` tag. It uses the highest requested decision —
+major, then minor, then patch — and creates or refreshes a single
+`release/next` pull request from the latest `main`. That release pull request
+contains the version and CHANGELOG commit and carries `release:skip` so it
+cannot recursively prepare another release.
+
+The workflow dispatches CI explicitly on `release/next`. After those checks
+pass, merge the release pull request. Its merge is the first time the new
+version appears on `main`.
+
+The Release workflow then verifies the code, publishes to npm with provenance,
+tags `v<version>`, and creates the GitHub Release. An already-published version
+is skipped successfully.
+
+## Operational notes
+
+- `release:skip` pull requests are ignored when the next version is selected.
+- Dependency updates use patch by default. Add `release:skip` manually when a
+  dependency change must not publish.
+- This repository currently requires a maintainer to merge `release/next`
+  after CI passes; repository auto-merge is disabled.
+- If the version on `main` differs from the latest `v*` tag, release
+  preparation stops instead of skipping over an incomplete publication.
+- npm publishing requires the configured trusted publisher or an `NPM_TOKEN`
+  repository secret.

--- a/scripts/collect-release-decision.mjs
+++ b/scripts/collect-release-decision.mjs
@@ -1,0 +1,124 @@
+#!/usr/bin/env node
+
+import { appendFileSync } from "node:fs";
+import { pathToFileURL } from "node:url";
+
+const RANKS = { skip: 0, patch: 1, minor: 2, major: 3 };
+const BUMPS = ["skip", "patch", "minor", "major"];
+
+export function classifyRelease(labels = []) {
+  const names = new Set(labels.map((label) => label.name ?? label));
+
+  if (names.has("release:skip")) return "skip";
+  if (names.has("release:major")) return "major";
+  if (names.has("release:minor")) return "minor";
+  return "patch";
+}
+
+export function highestRelease(current, candidate) {
+  return RANKS[candidate] > RANKS[current] ? candidate : current;
+}
+
+function cleanTitle(title) {
+  return title.replace(/\s+/g, " ").trim();
+}
+
+async function main() {
+  const token = process.env.GITHUB_TOKEN;
+  const repository = process.env.GITHUB_REPOSITORY;
+  const apiUrl = process.env.GITHUB_API_URL ?? "https://api.github.com";
+  const baseTag = process.env.RELEASE_BASE_TAG;
+  const baseBranch = process.env.RELEASE_BASE_BRANCH ?? "main";
+  const outputFile = process.env.GITHUB_OUTPUT;
+
+  if (!token || !repository || !baseTag || !outputFile) {
+    throw new Error(
+      "GITHUB_TOKEN, GITHUB_REPOSITORY, RELEASE_BASE_TAG, and GITHUB_OUTPUT are required."
+    );
+  }
+
+  const request = async (path) => {
+    const response = await fetch(`${apiUrl}${path}`, {
+      headers: {
+        Accept: "application/vnd.github+json",
+        Authorization: `Bearer ${token}`,
+        "X-GitHub-Api-Version": "2022-11-28",
+      },
+    });
+
+    if (!response.ok) {
+      const body = await response.text();
+      throw new Error(`GitHub API ${response.status} for ${path}: ${body}`);
+    }
+
+    return response.json();
+  };
+
+  const commits = [];
+  for (let page = 1; ; page += 1) {
+    const comparison = await request(
+      `/repos/${repository}/compare/${encodeURIComponent(baseTag)}...${encodeURIComponent(baseBranch)}` +
+        `?per_page=100&page=${page}`
+    );
+    commits.push(...comparison.commits);
+    if (comparison.commits.length < 100) break;
+  }
+
+  let bump = "skip";
+  const sources = [];
+  const seenPullRequests = new Set();
+
+  for (const commit of commits) {
+    const pulls = await request(
+      `/repos/${repository}/commits/${commit.sha}/pulls`
+    );
+    const mergedPulls = pulls.filter(
+      (pull) => pull.merged_at && pull.base?.ref === baseBranch
+    );
+
+    if (mergedPulls.length === 0) {
+      bump = highestRelease(bump, "patch");
+      sources.push(`- \`${commit.sha.slice(0, 7)}\` — direct commit (patch)`);
+      continue;
+    }
+
+    for (const pull of mergedPulls) {
+      if (seenPullRequests.has(pull.number)) continue;
+      seenPullRequests.add(pull.number);
+
+      const decision =
+        pull.head?.ref === "release/next"
+          ? "skip"
+          : classifyRelease(pull.labels);
+      bump = highestRelease(bump, decision);
+
+      if (decision !== "skip") {
+        sources.push(
+          `- #${pull.number} ${cleanTitle(pull.title)} (${decision})`
+        );
+      }
+    }
+  }
+
+  if (!BUMPS.includes(bump)) {
+    throw new Error(`Unsupported release decision: ${bump}`);
+  }
+
+  const delimiter = `release_sources_${Date.now()}`;
+  appendFileSync(
+    outputFile,
+    `bump=${bump}\n` +
+      `sources<<${delimiter}\n${sources.join("\n")}\n${delimiter}\n`
+  );
+
+  console.log(
+    `Compared ${commits.length} commit(s) after ${baseTag}; decision: ${bump}.`
+  );
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main().catch((error) => {
+    console.error(error instanceof Error ? error.message : error);
+    process.exit(1);
+  });
+}


### PR DESCRIPTION
Moves version changes out of source pull requests. After a non-skipped pull request merges, automation aggregates merged decisions since the latest version tag and creates or refreshes `release/next` from the latest `main`.

## What changed

- Replaced pre-merge version commits with a post-merge release-preparation workflow.
- Added a testable helper that reads merged pull request labels through the GitHub API and selects the highest pending bump.
- Dispatches CI explicitly on the bot-authored release branch.
- Documents the separate release PR and the commands for applying release decisions.
- Lets passing dependency updates use patch by default while preserving the existing groups.
- Removes the previously generated `1.0.4` bump from this pull request.

## Testing

- Parsed all GitHub workflow and Dependabot YAML files.
- Ran Node syntax and pure-logic assertions for release decision classification and precedence.
- `git diff --check`
- GitHub Actions passed typecheck, tests, build, package verification, and GitGuardian checks on Ubuntu and macOS.

## Risk

The generated `release/next` pull request must currently be merged by a maintainer after CI passes because repository auto-merge is disabled. This migration carries `release:skip`, so merging it does not prepare a release recursively.
