### PR TITLE
ci: release merged changes from main

### DIFF
--- a/.github/workflows/bump.yml
+++ b/.github/workflows/bump.yml
@@ -1,8 +1,8 @@
-name: Prepare release
+name: Release merged changes
 
-# Source pull requests never receive version commits. After a pull request is
-# merged, this workflow aggregates every merged change since the latest v* tag
-# and creates or refreshes one protected-path release pull request.
+# A source pull request never receives a version commit. After it is merged,
+# trusted code from main selects the highest release label since the latest tag
+# and commits the version bump directly to main.
 
 on:
   pull_request_target:
@@ -14,24 +14,24 @@ permissions:
   contents: read
 
 concurrency:
-  group: prepare-release
+  group: release-main
   cancel-in-progress: false
 
 jobs:
   prepare:
-    name: Create or update release PR
+    name: Bump version on main
     if: >-
       github.event_name == 'workflow_dispatch' ||
       (github.event.pull_request.merged == true &&
-       github.event.pull_request.head.ref != 'release/next' &&
        !contains(github.event.pull_request.labels.*.name, 'release:skip'))
     runs-on: ubuntu-latest
     timeout-minutes: 10
 
     permissions:
-      actions: write
       contents: write
-      pull-requests: write
+
+    outputs:
+      release_sha: ${{ steps.release.outputs.sha }}
 
     steps:
       # pull_request_target has a write-capable token. Only trusted code from
@@ -45,6 +45,11 @@ jobs:
         with:
           node-version: 22
 
+      - name: Sync main
+        run: |
+          git fetch --no-tags origin +refs/heads/main:refs/remotes/origin/main
+          git switch -C main origin/main
+
       - name: Verify the release baseline
         id: baseline
         run: |
@@ -53,12 +58,11 @@ jobs:
           MAIN_VERSION="$(node -p "require('./package.json').version")"
 
           if [ "$MAIN_VERSION" != "$TAG_VERSION" ]; then
-            echo "::error::main is version $MAIN_VERSION but the latest tag is $BASE_TAG. Finish or repair that release before preparing another one."
+            echo "::error::main is version $MAIN_VERSION but the latest tag is $BASE_TAG. Repair that release with release.yml before bumping again."
             exit 1
           fi
 
           echo "base_tag=$BASE_TAG" >> "$GITHUB_OUTPUT"
-          echo "main_version=$MAIN_VERSION" >> "$GITHUB_OUTPUT"
 
       - name: Collect merged release decisions
         id: decision
@@ -68,70 +72,31 @@ jobs:
           RELEASE_BASE_TAG: ${{ steps.baseline.outputs.base_tag }}
         run: node scripts/collect-release-decision.mjs
 
-      - name: Build the release commit
+      - name: Commit the version bump to main
         id: release
         if: steps.decision.outputs.bump != 'skip'
         env:
           BUMP: ${{ steps.decision.outputs.bump }}
         run: |
-          OLD_SHA="$(git ls-remote origin refs/heads/release/next | awk '{print $1}')"
-
-          git fetch --no-tags origin +refs/heads/main:refs/remotes/origin/main
-          git switch -C release/next origin/main
-
           npm version "$BUMP" --no-git-tag-version --allow-same-version > /dev/null
           TARGET="$(node -p "require('./package.json').version")"
-          echo "CHANGELOG: $(node scripts/release-changelog.mjs "$TARGET" "$(date -u +%Y-%m-%d)")"
+          node scripts/release-changelog.mjs "$TARGET" "$(date -u +%Y-%m-%d)"
 
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git add package.json CHANGELOG.md
           git commit -m "chore(release): v$TARGET"
+          git push origin HEAD:refs/heads/main
 
-          if [ -n "$OLD_SHA" ]; then
-            git push --force-with-lease="refs/heads/release/next:$OLD_SHA" origin HEAD:release/next
-          else
-            git push origin HEAD:release/next
-          fi
+          echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
 
-          echo "target=$TARGET" >> "$GITHUB_OUTPUT"
-
-      - name: Open or refresh the release PR
-        if: steps.decision.outputs.bump != 'skip'
-        env:
-          GH_TOKEN: ${{ github.token }}
-          SOURCES: ${{ steps.decision.outputs.sources }}
-          TARGET: ${{ steps.release.outputs.target }}
-        run: |
-          BODY="$RUNNER_TEMP/release-pr.md"
-          {
-            echo "Releases the merged changes below as **v$TARGET**."
-            echo
-            echo "## Included changes"
-            echo
-            printf '%s\n' "$SOURCES"
-            echo
-            echo "## Merge behavior"
-            echo
-            echo "Merging this pull request puts the version and CHANGELOG update on \`main\`. The Release workflow then verifies, publishes to npm, tags \`v$TARGET\`, and creates the GitHub Release."
-          } > "$BODY"
-
-          PR_NUMBER="$(gh pr list --state open --base main --head release/next --json number --jq '.[0].number // empty')"
-
-          if [ -z "$PR_NUMBER" ]; then
-            gh pr create \
-              --base main \
-              --head release/next \
-              --title "chore(release): v$TARGET" \
-              --body-file "$BODY" \
-              --label "release:skip"
-          else
-            gh pr edit "$PR_NUMBER" \
-              --title "chore(release): v$TARGET" \
-              --body-file "$BODY" \
-              --add-label "release:skip"
-          fi
-
-          # Pushes and pull requests created by GITHUB_TOKEN do not trigger
-          # ordinary workflows, so dispatch CI explicitly on the release SHA.
-          gh workflow run ci.yml --ref release/next
+  publish:
+    name: Publish the main release
+    needs: prepare
+    if: needs.prepare.outputs.release_sha != ''
+    permissions:
+      contents: write
+      id-token: write
+    uses: ./.github/workflows/release.yml
+    with:
+      ref: ${{ needs.prepare.outputs.release_sha }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,27 +1,16 @@
 name: Release
 
-# Publishes to npm when the version in package.json changes on `main`.
-#
-# Source pull request labels select semver after merge. The Prepare release
-# workflow puts that version in the dedicated `release/next` pull request.
-# Merging `release/next` is what releases. Everything after that merge —
-# publish, tag, GitHub Release — happens here. Pushes that do not change the
-# version are compared against the registry and skipped.
-#
-# Authentication uses npm trusted publishing (OIDC). There is no token to
-# store or rotate. Configure it once, at
-# https://www.npmjs.com/package/eas-local-cache/access
-# -> Trusted Publisher:
-#
-#   Organization or user:  dennytosp
-#   Repository:            eas-local-cache
-#   Workflow filename:     release.yml
-#   Environment name:      (leave blank)
-#
-# Until a trusted publisher is configured, the workflow falls back to an
-# `NPM_TOKEN` repository secret if one exists.
+# The post-merge workflow calls this file with the exact version-bump commit.
+# Manual dispatch remains available to repair an interrupted npm publish, tag,
+# or GitHub Release without incrementing the version again.
 
 on:
+  workflow_call:
+    inputs:
+      ref:
+        description: Commit containing the version to release
+        required: true
+        type: string
   push:
     branches: [main]
     paths: ["package.json"]
@@ -31,7 +20,7 @@ permissions:
   contents: read
 
 concurrency:
-  group: release
+  group: publish
   cancel-in-progress: false
 
 jobs:
@@ -45,6 +34,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v7
+        with:
+          ref: ${{ inputs.ref || github.sha }}
 
       - id: check
         run: |
@@ -52,13 +43,6 @@ jobs:
           VERSION="$(node -p "require('./package.json').version")"
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
 
-          # Ask the registry once for every published version.
-          #
-          # `npm view pkg@version` exits non-zero both when the version is
-          # genuinely unpublished and when the registry is unreachable, so
-          # using it directly would read a network blip as "not released yet"
-          # and try to publish. Fetch the version list instead and tell the two
-          # cases apart explicitly.
           set +e
           VERSIONS="$(npm view "$NAME" versions --json 2>&1)"
           STATUS=$?
@@ -75,8 +59,6 @@ jobs:
             exit 1
           fi
 
-          # A package with a single published version returns a bare string
-          # rather than an array.
           if printf '%s' "$VERSIONS" | node -e '
             let raw = "";
             process.stdin.on("data", (chunk) => (raw += chunk));
@@ -86,7 +68,7 @@ jobs:
               process.exit(all.includes(process.argv[1]) ? 0 : 1);
             });
           ' "$VERSION"; then
-            echo "$NAME@$VERSION is already on npm. Nothing to release."
+            echo "$NAME@$VERSION is already on npm. Skipping publish."
             echo "publish=false" >> "$GITHUB_OUTPUT"
           else
             echo "$NAME@$VERSION is not on npm. Releasing."
@@ -94,51 +76,54 @@ jobs:
           fi
 
   release:
-    name: Publish v${{ needs.check.outputs.version }}
+    name: Release v${{ needs.check.outputs.version }}
     needs: check
-    if: needs.check.outputs.publish == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 15
 
     permissions:
-      contents: write # push the version tag and create the GitHub Release
-      id-token: write # OIDC for trusted publishing and provenance
+      contents: write
+      id-token: write
 
     steps:
       - uses: actions/checkout@v7
+        with:
+          ref: ${{ inputs.ref || github.sha }}
 
       - uses: oven-sh/setup-bun@v2
+        if: needs.check.outputs.publish == 'true'
         with:
           bun-version: latest
 
       - uses: actions/setup-node@v7
+        if: needs.check.outputs.publish == 'true'
         with:
           node-version: 22
           registry-url: https://registry.npmjs.org
 
-      # Trusted publishing needs npm 11.5.1 or newer. The npm bundled with
-      # Node 22 predates it.
       - name: Use an npm that supports trusted publishing
+        if: needs.check.outputs.publish == 'true'
         run: npm install --global npm@latest
 
       - name: Install dependencies
+        if: needs.check.outputs.publish == 'true'
         run: bun install
 
       - name: Typecheck
+        if: needs.check.outputs.publish == 'true'
         run: bun run typecheck
 
       - name: Test
+        if: needs.check.outputs.publish == 'true'
         run: bun test
 
       - name: Build
+        if: needs.check.outputs.publish == 'true'
         run: bun run build
 
-      # Publishing comes before tagging on purpose: a failed publish should not
-      # leave a tag claiming a release that does not exist.
       - name: Publish to npm
+        if: needs.check.outputs.publish == 'true'
         run: npm publish --provenance --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Tag and create the GitHub Release
         env:
@@ -147,8 +132,6 @@ jobs:
         run: |
           TAG="v$VERSION"
 
-          # npm is already published by this point, so a pre-existing tag or
-          # release is reported and stepped over rather than failing the run.
           if git ls-remote --exit-code --tags origin "refs/tags/$TAG" > /dev/null 2>&1; then
             echo "::notice::Tag $TAG already exists on the remote. Leaving it as is."
           else
@@ -161,8 +144,6 @@ jobs:
             exit 0
           fi
 
-          # Prefer the matching CHANGELOG section; fall back to generated notes
-          # when this version has no entry.
           NOTES="$RUNNER_TEMP/release-notes.md"
           awk -v header="## [$VERSION]" '
             index($0, header) == 1 { found = 1; next }

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -109,7 +109,8 @@ Commit messages use a gitmoji + short summary style
 Source pull requests never bump their own version. After a merge into `main`,
 the default decision is patch when no `release:*` label is present; use
 `release:minor`, `release:major`, or `release:skip` to override it. Automation
-then prepares a separate `release/next` pull request whose merge publishes.
+then commits the selected version directly to `main`, verifies the package,
+publishes it to npm, and creates the matching tag and GitHub Release.
 
 Read [RELEASING.md](./RELEASING.md) for the complete rules and copy-pasteable
 `gh` commands for creating, applying, changing, and verifying release labels.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -117,29 +117,23 @@ Source pull requests run CI without changing `package.json` or `CHANGELOG.md`.
 The release decision is read only after a pull request has been merged into
 `main`.
 
-After a non-skipped merge, the Prepare release workflow examines every merged
-change since the latest `v*` tag. It uses the highest requested decision —
-major, then minor, then patch — and creates or refreshes a single
-`release/next` pull request from the latest `main`. That release pull request
-contains the version and CHANGELOG commit and carries `release:skip` so it
-cannot recursively prepare another release.
+After a non-skipped merge, the release workflow examines every merged change
+since the latest `v*` tag. It uses the highest requested decision — major,
+then minor, then patch — and commits the version and CHANGELOG update directly
+to `main`.
 
-The workflow dispatches CI explicitly on `release/next`. After those checks
-pass, merge the release pull request. Its merge is the first time the new
-version appears on `main`.
-
-The Release workflow then verifies the code, publishes to npm with provenance,
-tags `v<version>`, and creates the GitHub Release. An already-published version
-is skipped successfully.
+The same workflow then verifies that exact commit, publishes it to npm with
+provenance, tags `v<version>`, and creates the GitHub Release. There is no
+second release pull request to merge. An already-published version is not
+published twice, but missing tags or GitHub Releases are still repaired.
 
 ## Operational notes
 
 - `release:skip` pull requests are ignored when the next version is selected.
 - Dependency updates use patch by default. Add `release:skip` manually when a
   dependency change must not publish.
-- This repository currently requires a maintainer to merge `release/next`
-  after CI passes; repository auto-merge is disabled.
 - If the version on `main` differs from the latest `v*` tag, release
-  preparation stops instead of skipping over an incomplete publication.
-- npm publishing requires the configured trusted publisher or an `NPM_TOKEN`
-  repository secret.
+  preparation stops instead of bumping again. Repair the interrupted release
+  with `gh workflow run release.yml`; if unreleased merged changes remain, run
+  `gh workflow run bump.yml` afterward.
+- npm publishing requires the configured trusted publisher for `release.yml`.

--- a/scripts/collect-release-decision.mjs
+++ b/scripts/collect-release-decision.mjs
@@ -19,10 +19,6 @@ export function highestRelease(current, candidate) {
   return RANKS[candidate] > RANKS[current] ? candidate : current;
 }
 
-function cleanTitle(title) {
-  return title.replace(/\s+/g, " ").trim();
-}
-
 async function main() {
   const token = process.env.GITHUB_TOKEN;
   const repository = process.env.GITHUB_REPOSITORY;
@@ -65,7 +61,6 @@ async function main() {
   }
 
   let bump = "skip";
-  const sources = [];
   const seenPullRequests = new Set();
 
   for (const commit of commits) {
@@ -78,7 +73,6 @@ async function main() {
 
     if (mergedPulls.length === 0) {
       bump = highestRelease(bump, "patch");
-      sources.push(`- \`${commit.sha.slice(0, 7)}\` — direct commit (patch)`);
       continue;
     }
 
@@ -86,17 +80,8 @@ async function main() {
       if (seenPullRequests.has(pull.number)) continue;
       seenPullRequests.add(pull.number);
 
-      const decision =
-        pull.head?.ref === "release/next"
-          ? "skip"
-          : classifyRelease(pull.labels);
+      const decision = classifyRelease(pull.labels);
       bump = highestRelease(bump, decision);
-
-      if (decision !== "skip") {
-        sources.push(
-          `- #${pull.number} ${cleanTitle(pull.title)} (${decision})`
-        );
-      }
     }
   }
 
@@ -104,12 +89,7 @@ async function main() {
     throw new Error(`Unsupported release decision: ${bump}`);
   }
 
-  const delimiter = `release_sources_${Date.now()}`;
-  appendFileSync(
-    outputFile,
-    `bump=${bump}\n` +
-      `sources<<${delimiter}\n${sources.join("\n")}\n${delimiter}\n`
-  );
+  appendFileSync(outputFile, `bump=${bump}\n`);
 
   console.log(
     `Compared ${commits.length} commit(s) after ${baseTag}; decision: ${bump}.`


### PR DESCRIPTION
Release automation now changes the package version only after source code has merged into `main`. It removes the intermediate release pull request so the published version always originates from the latest accepted code.

## What changed

- Select patch by default, or minor/major/skip from the merged pull request label.
- Commit the version and CHANGELOG update directly to `main` from trusted workflow code.
- Publish the exact version-bump commit through a reusable `release.yml` workflow with npm trusted publishing.
- Make interrupted publish, tag, or GitHub Release operations safely repairable.
- Remove release-PR-only output and document the final commands and behavior.

## Testing

- `actionlint` 1.7.12 passed for every workflow in both repositories.
- `bun install --frozen-lockfile`
- `bun run typecheck`
- `bun test` — 13 passed, 0 failed.
- `bun run build`
- `npm pack --dry-run`
- Live GitHub release-decision check returned `patch` for the currently unreleased changes.
- `package.json`, npm latest, and latest Git tag all match `1.0.3`.

## Risk

The trusted post-merge workflow can make a fast-forward push to `main`. It checks out only `main`, serializes releases, verifies the latest tag baseline, and publishes the exact commit it created. Re-enable required pull requests and revert this commit to restore the previous release-PR model.
