### PR TITLE
fix(ci): preserve npm trusted publisher identity

### DIFF
--- a/.github/workflows/bump.yml
+++ b/.github/workflows/bump.yml
@@ -28,10 +28,8 @@ jobs:
     timeout-minutes: 10
 
     permissions:
+      actions: write
       contents: write
-
-    outputs:
-      release_sha: ${{ steps.release.outputs.sha }}
 
     steps:
       # pull_request_target has a write-capable token. Only trusted code from
@@ -90,13 +88,12 @@ jobs:
 
           echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
 
-  publish:
-    name: Publish the main release
-    needs: prepare
-    if: needs.prepare.outputs.release_sha != ''
-    permissions:
-      contents: write
-      id-token: write
-    uses: ./.github/workflows/release.yml
-    with:
-      ref: ${{ needs.prepare.outputs.release_sha }}
+      # npm validates the workflow that starts a run. Dispatching release.yml
+      # preserves its trusted-publisher identity; workflow_call would expose
+      # bump.yml as the caller and fail npm authentication.
+      - name: Dispatch the release
+        if: steps.decision.outputs.bump != 'skip'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_SHA: ${{ steps.release.outputs.sha }}
+        run: gh workflow run release.yml --ref main --field ref="$RELEASE_SHA"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,20 +1,19 @@
 name: Release
 
-# The post-merge workflow calls this file with the exact version-bump commit.
+# The post-merge workflow dispatches this file with the exact version-bump commit.
 # Manual dispatch remains available to repair an interrupted npm publish, tag,
 # or GitHub Release without incrementing the version again.
 
 on:
-  workflow_call:
+  workflow_dispatch:
     inputs:
       ref:
         description: Commit containing the version to release
-        required: true
+        required: false
         type: string
   push:
     branches: [main]
     paths: ["package.json"]
-  workflow_dispatch:
 
 permissions:
   contents: read


### PR DESCRIPTION
npm trusted publishing validates the workflow that starts a run. Calling `release.yml` as a reusable workflow exposes `bump.yml` as that identity and causes npm to reject an otherwise valid package publish.

## What changed

- Dispatch `release.yml` as an independent workflow after the version commit.
- Pass the exact version-commit SHA as a manual-dispatch input.
- Grant only the Actions permission needed to create that dispatch.
- Keep direct `release.yml` dispatch available for repairing version `1.0.4` without another bump.

## Testing

- `actionlint` 1.7.12 passed for all workflow files in both repositories.
- The full `1.0.4` release reached and passed install, typecheck, test, and build.
- The reusable-workflow publish failed only at npm authorization, matching npm's documented caller-workflow identity behavior.

## Risk

The bump run now completes after scheduling a separate release run, so publish status is reported in the `Release` workflow rather than as a nested job. The exact commit SHA and the existing publish concurrency guard prevent a later `main` update from changing the release contents.
