### PR TITLE
fix(ci): dispatch releases only after version selection

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,9 +16,6 @@ on:
         description: Release preparation run that requested this release
         required: false
         type: string
-  push:
-    branches: [main]
-    paths: ["package.json"]
 
 permissions:
   contents: read


### PR DESCRIPTION
Prevent package metadata changes on `main` from invoking the npm release workflow directly.

## What changed

- remove the `push` trigger from `release.yml`
- keep `workflow_dispatch` as the only release entry point
- preserve label selection, version verification, trusted publishing, tagging, and GitHub Release recovery

## Testing

- `bun run format:check`
- `bun run lint`
- `bun run typecheck`
- `bun test` — 17 passing

## Risk

Interrupted releases must be repaired with the documented manual `workflow_dispatch`; ordinary package changes can no longer bypass release-label selection.
