### PR TITLE
ci: use deploy key for version pushes

### DIFF
--- a/.github/workflows/bump.yml
+++ b/.github/workflows/bump.yml
@@ -40,6 +40,9 @@ jobs:
         with:
           ref: main
           fetch-depth: 0
+          # The write-enabled deploy key is the only automation identity that
+          # bypasses the required-status-check ruleset after verification.
+          ssh-key: ${{ secrets.RELEASE_DEPLOY_KEY }}
 
       - uses: actions/setup-node@v7
         with:


### PR DESCRIPTION
## Summary

- authenticate release version pushes with the repository-scoped deploy key
- preserve the required status-check ruleset for all other actors
- keep the existing verified version-commit flow unchanged