### PR TITLE
feat(cache): explain misses and track cache savings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   including JSON output and a non-mutating prune preview.
 - Atomic last-access metadata and automatic TTL/LRU cleanup with configurable
   size and entry-count soft caps.
+- Privacy-safe Expo fingerprint snapshots and evidence-backed cache-miss
+  explanations without persisting raw config or source contents.
+- Bounded per-resolve telemetry with retained hit rate, lookup duration, and a
+  conservative artifact-timestamp estimate of native build time avoided.
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ instead of compiling it again.
 - **Atomic and self-healing entries** that reject partial or corrupted builds
 - **Automatic storage limits** with TTL and least-recently-used cleanup
 - **Cache Inspector CLI** for capacity, entry, health, and prune operations
+- **Explainable cache misses** based on privacy-safe Expo fingerprint evidence
+- **Local hit-rate telemetry** with conservative estimated time saved
 - **Typed TypeScript implementation** with no runtime changes to your app
 
 ---
@@ -127,6 +129,12 @@ Concurrent builds for the same fingerprint coordinate through a per-entry lock.
 Incomplete staging data is never used, and a versioned entry that fails its
 manifest or integrity checks is moved to quarantine and treated as a cache miss.
 
+The provider retains only bounded, sanitized fingerprint descriptors beside new
+entries. On an ordinary miss it compares those descriptors and reports up to
+three evidence groups, such as Expo config or native dependency changes. Raw
+Expo config, source contents, absolute paths, device IDs, and arbitrary reason
+strings are never written to diagnostic metadata.
+
 After a successful upload, automatic maintenance removes expired data first and
 then least-recently-used entries until the size and entry-count soft caps are
 satisfied. The new artifact, recently returned artifacts, and active builds are
@@ -149,10 +157,12 @@ npx eas-local-cache prune --max-size 10GB --max-entries 20 --retention-days 7
 
 Every command accepts `--project-root <path>` and `--json` for automation.
 `doctor` performs the same full identity and integrity checks used by cache
-resolution without changing the cache. `prune
---dry-run` uses the same planner as real and automatic cleanup. Stats report
-exact bytes and counts; hit rate and estimated time saved remain unavailable
-until resolve/build event telemetry is added.
+resolution without changing the cache. `prune --dry-run` uses the same planner
+as real and automatic cleanup. Stats report exact bytes and counts plus hit rate
+for retained local decisions. Estimated time saved uses a conservative
+native-artifact timestamp sample; a hit without reliable timing remains
+explicitly unknown. Telemetry is retained for 90 days and at most 10,000
+events, independent of `autoPrune`.
 
 The cache is resolved from the project root supplied by Expo, not the current
 working directory. This keeps caches isolated when commands are run from a
@@ -169,12 +179,14 @@ Versioned artifacts are stored under `.expo/cache/eas-local-cache/v1`:
 | `locks/`      | Per-entry writer coordination                 |
 | `quarantine/` | Invalid entries retained for diagnosis        |
 | `access/`     | Atomic last-used records and short leases     |
+| `events/`     | Bounded, private resolve telemetry            |
 | `state/`      | Last valid cleanup policy                     |
 | `trash/`      | Atomic removal tombstones                     |
 
-Each entry contains `artifact.app` or `artifact.apk` plus `manifest.json`. The
-directory name is a SHA-256 cache identity, so fingerprint values never become
-raw filesystem paths. Flat `ios_<fingerprint>.app` and
+Each entry contains `artifact.app` or `artifact.apk` plus `manifest.json` and,
+for new builds, optional privacy-safe `insight.json`. The directory name is a
+SHA-256 cache identity, so fingerprint values never become raw filesystem
+paths. Flat `ios_<fingerprint>.app` and
 `android_<fingerprint>.apk` entries created by earlier releases remain readable
 for backward compatibility but are reported as unverified legacy entries.
 
@@ -199,7 +211,7 @@ control.
 - Check that `.expo/cache` exists in the Expo project root.
 - Make sure the native build inputs have not changed. A changed fingerprint is
   expected to produce a cache miss.
-- Look for `Cache hit` or `Cache miss` in the Expo CLI output.
+- Look for `Cache hit`, `Cache miss`, and `Possible cause` in Expo CLI output.
 
 ### Clear the local cache
 
@@ -227,6 +239,10 @@ bun run build
 bun install --cwd example
 bun run --cwd example ios
 bun run --cwd example ios
+# explained A miss → A hit → B config miss → B hit
+bun run --cwd example cache:test:ios
+# build-only iOS oracle (no Simulator launch required)
+EAS_LOCAL_CACHE_TEST_DEVICE=generic bun run --cwd example cache:test:ios
 ```
 
 Use an iOS Simulator, or replace `ios` with `android` after starting an

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -25,6 +25,8 @@ Status: implemented on `feat/cache-inspector`.
 
 ## Milestone 3: Explainable Cache
 
+Status: implemented on `feat/explain-cache-miss`.
+
 - Persist comparable fingerprint input snapshots
 - Compare a miss with the closest compatible previous entry
 - Report evidence-backed changed input groups as possible miss causes
@@ -37,7 +39,14 @@ Status: implemented on `feat/cache-inspector`.
   signals
 - Keep strict toolchain keying opt-in where compatibility is uncertain
 
-## Milestone 5: Trusted LAN Cache
+## Milestone 5: Storage Efficiency
+
+- Optional zstd compression for artifacts at rest
+- Bounded, atomic restore staging for Expo-compatible artifact paths
+- Compression savings visible in Cache Inspector output
+- Automatic fallback when zstd is unavailable or compressed data is damaged
+
+## Milestone 6: Trusted LAN Cache
 
 - Opt-in `serve` and `pair` workflow instead of ambient peer trust
 - Authenticated peer discovery and transfer

--- a/docs/superpowers/plans/2026-08-13-explainable-cache-implementation.md
+++ b/docs/superpowers/plans/2026-08-13-explainable-cache-implementation.md
@@ -1,0 +1,61 @@
+# Explainable Cache Implementation Plan
+
+## Delivery target
+
+Implement roadmap milestone 3 on `feat/explain-cache-miss` without changing
+Expo's default fingerprint hash or weakening M1/M2 cache correctness.
+
+## Work packages
+
+1. Fingerprint and insight metadata
+
+   - Normalize requested run profiles.
+   - Load project-local `@expo/fingerprint` and preserve Expo hash parity.
+   - Sanitize and bound source snapshots without raw contents, reasons, IDs, or
+     absolute paths.
+   - Atomically write and safely read optional entry insights.
+   - Diff snapshots, group evidence, and select the closest compatible entry.
+
+2. Resolve events and timing
+
+   - Store one bounded immutable event per resolve under UTC day buckets.
+   - Enforce 90-day and 10,000-event limits under a dedicated lock.
+   - Summarize retained hit/miss/error rates and conservative time saved.
+   - Calculate artifact-ready estimates from validated file mtimes.
+
+3. Provider and store integration
+
+   - Add a detailed resolve result while retaining the path-or-null API.
+   - Track calculation snapshots separately from miss build contexts.
+   - Publish insights only with new immutable entries.
+   - Log direct miss reasons before heuristic evidence.
+   - Record telemetry without making a build depend on diagnostics.
+
+4. Inspector integration
+
+   - Add event paths, bytes, counts, and issues to inventory and doctor.
+   - Prune telemetry separately from artifact capacity decisions.
+   - Replace placeholder CLI hit-rate/time-saved fields with retained summaries.
+
+5. Example verification
+
+   - Add a conditional Expo config salt.
+   - Verify provider fingerprint callback and config parity statically.
+   - Document and automate the repeatable A/A/B/B native oracle.
+
+6. Verification and delivery
+   - Run formatting, lint, typecheck, all Bun tests, package build, example
+     checks, export smoke test, tarball consumer test, and iOS native A/A/B/B.
+   - Request independent read-only code review and address findings.
+   - Commit focused implementation changes, push the stacked branch, create the
+     pull request, and monitor CI to green before starting milestone 4.
+
+## Compatibility rules
+
+- Entries without `insight.json` stay valid.
+- Diagnostic metadata never changes cache validity or cache identity.
+- Telemetry and insight failures fail open.
+- Raw fingerprints appear only in immutable manifest identity, as before; event
+  records use entry IDs and logs use short hashes.
+- Event bytes are bounded operational metadata and never evict artifacts for
+  `maxSize` compliance.

--- a/example/README.md
+++ b/example/README.md
@@ -28,12 +28,15 @@ bun install
 bun run verify:provider
 ```
 
-The verification checks all three integration points:
+The verification checks the integration points:
 
 - `package.json` links `eas-local-cache` from the repository root.
 - `app.json` configures `expo.buildCacheProvider` with that package.
-- The built package exports `resolveBuildCache` and `uploadBuildCache`.
+- The built package exports `calculateFingerprintHash`, `resolveBuildCache`, and
+  `uploadBuildCache`.
 - The package exposes the `eas-local-cache` inspector binary.
+- A conditional `EAS_LOCAL_CACHE_TEST_SALT` changes evaluated Expo config
+  without editing tracked or native files.
 
 ## Test a real cache round trip
 
@@ -108,3 +111,24 @@ bun run verify:provider
 The `bun run ios` and `bun run android` scripts execute native Expo builds and
 therefore exercise the build cache provider. Use `bun run start` when you only
 need the Metro development server.
+
+## Test an explained cache miss
+
+The automated native oracle generates two non-secret per-run config tokens and
+runs A miss → A hit → B explained miss → B hit:
+
+```bash
+bun run cache:test:ios
+# or, with an Android emulator already running
+bun run cache:test:android
+```
+
+Set `EAS_LOCAL_CACHE_TEST_DEVICE` to `generic` for an iOS build-only run, an iOS
+Simulator UDID for an install-and-launch run, or an Android emulator serial
+when more than one target is available.
+
+The B miss must identify Expo configuration as a possible cause. The script
+also requires exactly two new misses and two new hits, scans diagnostics for
+token leaks, and requires a healthy cache at the end. Tokens are not written to
+insight or event metadata; they only make Expo's evaluated config fingerprint
+change.

--- a/example/app.config.js
+++ b/example/app.config.js
@@ -1,0 +1,18 @@
+const staticConfig = require("./app.json");
+
+module.exports = () => {
+  const config = staticConfig.expo;
+  const testSalt = process.env.EAS_LOCAL_CACHE_TEST_SALT;
+
+  if (!testSalt) {
+    return config;
+  }
+
+  return {
+    ...config,
+    extra: {
+      ...config.extra,
+      easLocalCacheTestSalt: testSalt,
+    },
+  };
+};

--- a/example/package.json
+++ b/example/package.json
@@ -8,6 +8,8 @@
     "android": "expo run:android",
     "ios": "expo run:ios",
     "verify:provider": "node ./scripts/verify-provider.mjs",
+    "cache:test:ios": "bash ./scripts/test-cache-native.sh ios",
+    "cache:test:android": "bash ./scripts/test-cache-native.sh android",
     "cache:stats": "node ../build/cli-bin.js stats --project-root .",
     "cache:list": "node ../build/cli-bin.js list --project-root .",
     "cache:doctor": "node ../build/cli-bin.js doctor --project-root .",

--- a/example/scripts/test-cache-native.sh
+++ b/example/scripts/test-cache-native.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+platform="${1:-}"
+if [[ "$platform" != "ios" && "$platform" != "android" ]]; then
+  echo "Usage: test-cache-native.sh ios|android" >&2
+  exit 2
+fi
+
+run_id="$(date +%s)-${RANDOM}-${RANDOM}"
+salt_a="m3-a-${run_id}"
+salt_b="m3-b-${run_id}"
+log_dir="$(mktemp -d "${TMPDIR:-/tmp}/eas-local-cache-native.XXXXXX")"
+cache_root=".expo/cache/eas-local-cache/v1"
+before_stats="$(node ../build/cli-bin.js stats --project-root . --json)"
+
+cleanup() {
+  if [[ "$log_dir" == "${TMPDIR:-/tmp}/eas-local-cache-native."* ]]; then
+    rm -rf "$log_dir"
+  fi
+}
+trap cleanup EXIT
+
+run_build() {
+  local salt="$1"
+  local label="$2"
+  local device_args=()
+  if [[ -n "${EAS_LOCAL_CACHE_TEST_DEVICE:-}" ]]; then
+    device_args=(--device "$EAS_LOCAL_CACHE_TEST_DEVICE")
+  fi
+  EAS_LOCAL_CACHE_TEST_SALT="$salt" bunx expo "run:${platform}" \
+    "${device_args[@]}" --no-bundler --no-install 2>&1 | \
+    tee "$log_dir/${label}.log"
+}
+
+run_build "$salt_a" a-miss
+run_build "$salt_a" a-hit
+run_build "$salt_b" b-miss
+run_build "$salt_b" b-hit
+
+grep -q "Cache miss for ${platform}" "$log_dir/a-miss.log"
+grep -q "Cache hit for ${platform}" "$log_dir/a-hit.log"
+grep -q "Cache miss for ${platform}" "$log_dir/b-miss.log"
+grep -qi "Expo config" "$log_dir/b-miss.log"
+grep -q "Cache hit for ${platform}" "$log_dir/b-hit.log"
+
+after_stats="$(node ../build/cli-bin.js stats --project-root . --json)"
+node -e '
+  const before = JSON.parse(process.argv[1]).telemetry;
+  const after = JSON.parse(process.argv[2]).telemetry;
+  const delta = (field) => after[field] - before[field];
+  if (delta("hits") !== 2 || delta("misses") !== 2 || delta("errors") !== 0) {
+    throw new Error(
+      `Expected telemetry delta hits=2, misses=2, errors=0; received hits=${delta("hits")}, misses=${delta("misses")}, errors=${delta("errors")}`
+    );
+  }
+' "$before_stats" "$after_stats"
+
+if rg --quiet --fixed-strings --glob '*.json' \
+  -e "$salt_a" -e "$salt_b" "$cache_root/events" "$cache_root/entries"; then
+  echo "Raw cache test salt leaked into diagnostic metadata" >&2
+  exit 1
+fi
+
+node ../build/cli-bin.js doctor --project-root .
+echo "Verified ${platform} miss/hit/config-change/hit flow, telemetry, and diagnostic privacy."

--- a/example/scripts/verify-provider.mjs
+++ b/example/scripts/verify-provider.mjs
@@ -1,3 +1,4 @@
+import { execFileSync } from "node:child_process";
 import { readFileSync } from "node:fs";
 import { createRequire } from "node:module";
 
@@ -32,10 +33,35 @@ if (configuredPlugin !== "eas-local-cache") {
   );
 }
 
-for (const method of ["resolveBuildCache", "uploadBuildCache"]) {
+for (const method of ["calculateFingerprintHash", "resolveBuildCache", "uploadBuildCache"]) {
   if (typeof provider?.[method] !== "function") {
     throw new TypeError(`The local provider does not export ${method}()`);
   }
+}
+
+const evaluateConfig = (salt) => {
+  const output = execFileSync(
+    process.execPath,
+    ["./node_modules/expo/bin/cli", "config", "--type", "public", "--json"],
+    {
+      cwd: new URL("..", import.meta.url),
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        ...(salt ? { EAS_LOCAL_CACHE_TEST_SALT: salt } : {}),
+      },
+    }
+  );
+  return JSON.parse(output);
+};
+
+const configWithoutSalt = evaluateConfig(null);
+const configWithSalt = evaluateConfig("non-secret-provider-verification");
+if (configWithoutSalt.extra?.easLocalCacheTestSalt !== undefined) {
+  throw new Error("The cache test salt must be omitted unless explicitly set");
+}
+if (configWithSalt.extra?.easLocalCacheTestSalt !== "non-secret-provider-verification") {
+  throw new Error("Dynamic Expo config did not expose the cache test salt");
 }
 
 if (providerPackageJson.bin?.["eas-local-cache"] !== "build/cli-bin.js") {

--- a/src/cache/catalog.ts
+++ b/src/cache/catalog.ts
@@ -2,6 +2,7 @@ import * as fs from "fs";
 import * as path from "path";
 
 import { readAccessRecord } from "./access";
+import { scanResolveEvents } from "./events";
 import {
   assertManagedDirectory,
   assertProviderRoot,
@@ -44,6 +45,10 @@ export type CacheCatalog = {
     protectedUntil: string | null;
   }>;
   issues: CatalogIssue[];
+  telemetry: {
+    eventCount: number;
+    invalidEventCount: number;
+  };
   usage: {
     entriesBytes: number;
     invalidEntriesBytes: number;
@@ -53,6 +58,7 @@ export type CacheCatalog = {
     accessBytes: number;
     stateBytes: number;
     locksBytes: number;
+    eventsBytes: number;
     otherBytes: number;
     legacyBytes: number;
     managedBytes: number;
@@ -345,6 +351,7 @@ export const inventoryCache = (projectRoot: string): CacheCatalog => {
       entries: [],
       invalidEntries: [],
       issues: [],
+      telemetry: { eventCount: 0, invalidEventCount: 0 },
       legacyEntries,
       usage: {
         entriesBytes: 0,
@@ -355,6 +362,7 @@ export const inventoryCache = (projectRoot: string): CacheCatalog => {
         accessBytes: 0,
         stateBytes: 0,
         locksBytes: 0,
+        eventsBytes: 0,
         otherBytes: 0,
         legacyBytes,
         managedBytes: 0,
@@ -380,6 +388,7 @@ export const inventoryCache = (projectRoot: string): CacheCatalog => {
           severity: "error",
         },
       ],
+      telemetry: { eventCount: 0, invalidEventCount: 0 },
       legacyEntries: [],
       usage: {
         entriesBytes: 0,
@@ -390,6 +399,7 @@ export const inventoryCache = (projectRoot: string): CacheCatalog => {
         accessBytes: 0,
         stateBytes: 0,
         locksBytes: 0,
+        eventsBytes: 0,
         otherBytes: 0,
         legacyBytes: 0,
         managedBytes: 0,
@@ -448,6 +458,37 @@ export const inventoryCache = (projectRoot: string): CacheCatalog => {
     issues,
     "unsafe-locks-root"
   );
+  const eventsBytes = safeDirectorySize(
+    paths.providerRoot,
+    paths.eventsRoot,
+    issues,
+    "unsafe-events-root"
+  );
+  let eventCount = 0;
+  let invalidEventCount = 0;
+  try {
+    const eventScan = scanResolveEvents(paths.eventsRoot);
+    eventCount = eventScan.events.length;
+    invalidEventCount = eventScan.invalid.length;
+    for (const invalid of eventScan.invalid) {
+      issues.push({
+        code: "invalid-resolve-event",
+        path: invalid.filePath,
+        message: invalid.reason,
+        severity: "warning",
+      });
+    }
+  } catch (error) {
+    if (pathExists(paths.eventsRoot)) {
+      issues.push({
+        code: "unreadable-events-root",
+        path: paths.eventsRoot,
+        message:
+          error instanceof Error ? error.message : "Events root is unreadable",
+        severity: "error",
+      });
+    }
+  }
   const legacyBytes = legacyEntries.reduce(
     (total, entry) => total + entry.sizeBytes,
     0
@@ -460,7 +501,8 @@ export const inventoryCache = (projectRoot: string): CacheCatalog => {
     trashBytes +
     accessBytes +
     stateBytes +
-    locksBytes;
+    locksBytes +
+    eventsBytes;
   const otherBytes = Math.max(0, providerBytes - categorizedProviderBytes);
   const managedBytes =
     entriesStorageBytes + stagingBytes + quarantineBytes + trashBytes;
@@ -471,6 +513,7 @@ export const inventoryCache = (projectRoot: string): CacheCatalog => {
     entries,
     invalidEntries,
     issues,
+    telemetry: { eventCount, invalidEventCount },
     legacyEntries,
     usage: {
       entriesBytes,
@@ -481,6 +524,7 @@ export const inventoryCache = (projectRoot: string): CacheCatalog => {
       accessBytes,
       stateBytes,
       locksBytes,
+      eventsBytes,
       otherBytes,
       legacyBytes,
       managedBytes,

--- a/src/cache/cleanup.ts
+++ b/src/cache/cleanup.ts
@@ -14,6 +14,7 @@ import {
   ensureManagedDirectory,
   pathExists,
 } from "./filesystem";
+import { pruneResolveEvents, type ResolveEventPruneCandidate } from "./events";
 import { acquireEntryLock, inspectEntryLock, releaseEntryLock } from "./lock";
 import type { NormalizedCachePolicy } from "./options";
 
@@ -33,6 +34,9 @@ export type PruneResult = {
   removed: PruneCandidate[];
   auxiliaryCandidates: AuxiliaryPruneCandidate[];
   auxiliaryRemoved: AuxiliaryPruneCandidate[];
+  telemetryCandidates: ResolveEventPruneCandidate[];
+  telemetryRemoved: ResolveEventPruneCandidate[];
+  telemetryReclaimedBytes: number;
   skipped: Array<{ entryId: string; reason: string }>;
   reclaimedBytes: number;
   remainingEntries: number;
@@ -332,6 +336,23 @@ export const pruneCache = async (
   const catalog = inventoryCache(projectRoot);
   const now = options.now ?? new Date();
   const nowMs = now.getTime();
+  const telemetryPrune = await pruneResolveEvents(
+    catalog.paths.providerRoot,
+    catalog.paths.eventsRoot,
+    { dryRun: options.dryRun, nowMs }
+  );
+  const telemetryCandidates =
+    telemetryPrune.status === "pruned" ? telemetryPrune.candidates : [];
+  const telemetryRemoved =
+    telemetryPrune.status === "pruned" ? telemetryPrune.removed : [];
+  const telemetryReclaimedBytes =
+    telemetryPrune.status === "pruned" ? telemetryPrune.removedBytes : 0;
+  const telemetryIssues =
+    telemetryPrune.status === "failed"
+      ? [`Could not prune telemetry: ${telemetryPrune.error.message}`]
+      : telemetryPrune.status === "lock-busy"
+      ? ["Could not acquire the telemetry maintenance lock"]
+      : [];
   const protectedEntryIds = new Set(options.protectedEntryIds ?? []);
   const auxiliaryCandidates = addAuxiliaryForSize(
     catalog,
@@ -378,6 +399,9 @@ export const pruneCache = async (
       removed: [],
       auxiliaryCandidates,
       auxiliaryRemoved: [],
+      telemetryCandidates,
+      telemetryRemoved,
+      telemetryReclaimedBytes,
       skipped: [],
       reclaimedBytes,
       remainingEntries: initialCount - candidates.length,
@@ -387,7 +411,10 @@ export const pruneCache = async (
         remainingBytes,
         policy
       ),
-      issues: catalog.issues.map((issue) => `${issue.code}: ${issue.message}`),
+      issues: [
+        ...catalog.issues.map((issue) => `${issue.code}: ${issue.message}`),
+        ...telemetryIssues,
+      ],
     };
   }
 
@@ -404,6 +431,9 @@ export const pruneCache = async (
       removed: [],
       auxiliaryCandidates,
       auxiliaryRemoved: [],
+      telemetryCandidates,
+      telemetryRemoved,
+      telemetryReclaimedBytes,
       skipped: candidates.map((entry) => ({
         entryId: entry.entryId,
         reason: "maintenance is already running",
@@ -416,7 +446,7 @@ export const pruneCache = async (
         initialBytes + auxiliaryBytes,
         policy
       ),
-      issues: ["Could not acquire the maintenance lock"],
+      issues: ["Could not acquire the maintenance lock", ...telemetryIssues],
     };
   }
 
@@ -426,6 +456,7 @@ export const pruneCache = async (
   const issues = catalog.issues.map(
     (issue) => `${issue.code}: ${issue.message}`
   );
+  issues.push(...telemetryIssues);
   try {
     ensureManagedDirectory(catalog.paths.providerRoot, catalog.paths.trashRoot);
     for (const candidate of auxiliaryCandidates) {
@@ -624,6 +655,9 @@ export const pruneCache = async (
     removed,
     auxiliaryCandidates,
     auxiliaryRemoved,
+    telemetryCandidates,
+    telemetryRemoved,
+    telemetryReclaimedBytes,
     skipped,
     reclaimedBytes,
     remainingEntries,

--- a/src/cache/doctor.ts
+++ b/src/cache/doctor.ts
@@ -2,6 +2,7 @@ import * as fs from "fs";
 
 import { inventoryCache, type CatalogIssue } from "./catalog";
 import { assertManagedDirectory } from "./filesystem";
+import { readInsight } from "./insight";
 import { validateEntry } from "./validation";
 
 export type DoctorReport = {
@@ -28,6 +29,25 @@ export const doctorCache = (projectRoot: string): DoctorReport => {
         path: entry.directory,
         message: validation.reason,
         severity: "error",
+      });
+    }
+    try {
+      const insight = readInsight(entry.directory);
+      if (
+        insight &&
+        (insight.entryId !== entry.entryId ||
+          insight.platform !== entry.platform ||
+          insight.fingerprintHash !== entry.fingerprintHash)
+      ) {
+        throw new Error("Cache insight identity does not match its entry");
+      }
+    } catch (error) {
+      issues.push({
+        code: "invalid-cache-insight",
+        path: `${entry.directory}/insight.json`,
+        message:
+          error instanceof Error ? error.message : "Cache insight is invalid",
+        severity: "warning",
       });
     }
   }

--- a/src/cache/events.ts
+++ b/src/cache/events.ts
@@ -1,0 +1,806 @@
+import * as crypto from "crypto";
+import * as fs from "fs";
+import * as os from "os";
+import * as path from "path";
+
+import { ensureRealDirectoryTree, isPathInside } from "./filesystem";
+import type { CachePlatform } from "./paths";
+
+export const RESOLVE_EVENT_SCHEMA_VERSION = 1;
+export const RESOLVE_EVENT_RETENTION_DAYS = 90;
+export const RESOLVE_EVENT_MAX_COUNT = 10_000;
+export const RESOLVE_EVENT_MAX_BYTES = 16 * 1024;
+export const RESOLVE_EVENT_MAX_LOOKUP_DURATION_MS = 24 * 60 * 60 * 1000;
+export const RESOLVE_EVENT_MAX_TIME_SAVED_MS = 6 * 60 * 60 * 1000;
+
+const RETENTION_MS = RESOLVE_EVENT_RETENTION_DAYS * 24 * 60 * 60 * 1000;
+const EVENT_DAY_PATTERN = /^\d{4}-\d{2}-\d{2}$/;
+const EVENT_FILE_PATTERN =
+  /^(\d{8}T\d{9}Z)-([a-f0-9]{8}-[a-f0-9]{4}-4[a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12})\.json$/;
+const EVENT_TEMP_FILE_PATTERN =
+  /^\.tmp-\d+-[a-f0-9]{8}-[a-f0-9]{4}-4[a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$/;
+const ENTRY_ID_PATTERN = /^[a-f0-9]{64}$/;
+
+export const RESOLVE_EXPLANATION_CODES = [
+  "hit",
+  "no-entry",
+  "corrupt-entry",
+  "writer-lock-busy",
+  "unsafe-legacy-path",
+  "legacy-invalid",
+  "provider-error",
+  "fingerprint-unavailable",
+  "expo-config-changed",
+  "native-dependencies-changed",
+  "native-project-changed",
+  "project-metadata-changed",
+  "other-inputs-changed",
+  "no-compatible-insight",
+  "fingerprint-engine-mismatch",
+] as const;
+
+export type ResolveExplanationCode = (typeof RESOLVE_EXPLANATION_CODES)[number];
+export type ResolveEventOutcome = "hit" | "miss" | "error";
+
+export type ResolveEvent = {
+  schemaVersion: 1;
+  timestamp: string;
+  platform: CachePlatform;
+  entryId: string;
+  outcome: ResolveEventOutcome;
+  lookupDurationMs: number;
+  explanationCode: ResolveExplanationCode;
+  estimatedTimeSavedMs?: number;
+};
+
+export type ResolveEventInput = Omit<
+  ResolveEvent,
+  "schemaVersion" | "timestamp"
+>;
+
+export type StoredResolveEvent = {
+  event: ResolveEvent;
+  filePath: string;
+  sizeBytes: number;
+};
+
+export type InvalidResolveEvent = {
+  filePath: string;
+  sizeBytes: number;
+  reason: string;
+};
+
+export type ResolveEventScan = {
+  events: StoredResolveEvent[];
+  invalid: InvalidResolveEvent[];
+  validBytes: number;
+  invalidBytes: number;
+  totalBytes: number;
+};
+
+export type ResolveEventSummary = {
+  eventCount: number;
+  hits: number;
+  misses: number;
+  errors: number;
+  hitRate: number | null;
+  lookupDurationMs: number;
+  estimatedTimeSavedMs: number;
+  hitsWithoutEstimate: number;
+  windowStart: string | null;
+  windowEnd: string | null;
+};
+
+export type RecordResolveEventResult =
+  | { status: "recorded"; event: ResolveEvent; filePath: string }
+  | { status: "lock-busy" }
+  | { status: "failed"; error: Error };
+
+export type ResolveEventPruneCandidate = {
+  filePath: string;
+  timestamp: string | null;
+  sizeBytes: number;
+  reason: "invalid" | "expired" | "event-count";
+};
+
+export type PruneResolveEventsResult =
+  | {
+      status: "pruned";
+      candidates: ResolveEventPruneCandidate[];
+      removed: ResolveEventPruneCandidate[];
+      removedCount: number;
+      removedBytes: number;
+    }
+  | { status: "lock-busy" }
+  | { status: "failed"; error: Error };
+
+type EventLock = {
+  directory: string;
+  token: string;
+};
+
+type EventLockOwner = {
+  token: string;
+  pid: number;
+  hostname: string;
+  createdAt: string;
+};
+
+export type RecordResolveEventOptions = {
+  nowMs?: number;
+  maxLockWaitMs?: number;
+  lockRetryIntervalMs?: number;
+  staleLockMs?: number;
+  randomUUID?: () => string;
+};
+
+export type PruneResolveEventsOptions = Pick<
+  RecordResolveEventOptions,
+  "nowMs" | "maxLockWaitMs" | "lockRetryIntervalMs" | "staleLockMs"
+> & {
+  dryRun?: boolean;
+};
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null && !Array.isArray(value);
+
+const isBoundedNonNegative = (
+  value: unknown,
+  maximum: number
+): value is number =>
+  typeof value === "number" &&
+  Number.isFinite(value) &&
+  value >= 0 &&
+  value <= maximum;
+
+const isCanonicalTimestamp = (value: unknown): value is string => {
+  if (typeof value !== "string") {
+    return false;
+  }
+  const timestamp = Date.parse(value);
+  return (
+    Number.isFinite(timestamp) && new Date(timestamp).toISOString() === value
+  );
+};
+
+const isExplanationCode = (value: unknown): value is ResolveExplanationCode =>
+  typeof value === "string" &&
+  (RESOLVE_EXPLANATION_CODES as readonly string[]).includes(value);
+
+const parseResolveEvent = (value: unknown): ResolveEvent => {
+  if (!isRecord(value)) {
+    throw new Error("Resolve event must be an object");
+  }
+
+  const allowedKeys = new Set([
+    "schemaVersion",
+    "timestamp",
+    "platform",
+    "entryId",
+    "outcome",
+    "lookupDurationMs",
+    "explanationCode",
+    "estimatedTimeSavedMs",
+  ]);
+  if (Object.keys(value).some((key) => !allowedKeys.has(key))) {
+    throw new Error("Resolve event contains unsupported fields");
+  }
+
+  const valid =
+    value.schemaVersion === RESOLVE_EVENT_SCHEMA_VERSION &&
+    isCanonicalTimestamp(value.timestamp) &&
+    (value.platform === "android" || value.platform === "ios") &&
+    typeof value.entryId === "string" &&
+    ENTRY_ID_PATTERN.test(value.entryId) &&
+    (value.outcome === "hit" ||
+      value.outcome === "miss" ||
+      value.outcome === "error") &&
+    isBoundedNonNegative(
+      value.lookupDurationMs,
+      RESOLVE_EVENT_MAX_LOOKUP_DURATION_MS
+    ) &&
+    isExplanationCode(value.explanationCode) &&
+    (value.estimatedTimeSavedMs === undefined ||
+      (value.outcome === "hit" &&
+        isBoundedNonNegative(
+          value.estimatedTimeSavedMs,
+          RESOLVE_EVENT_MAX_TIME_SAVED_MS
+        )));
+
+  if (!valid) {
+    throw new Error("Resolve event contains malformed fields");
+  }
+
+  return value as ResolveEvent;
+};
+
+const getUtcDay = (timestamp: string): string => timestamp.slice(0, 10);
+
+const getTimestampToken = (timestamp: string): string =>
+  timestamp.replaceAll("-", "").replaceAll(":", "").replace(".", "");
+
+const delay = (durationMs: number): Promise<void> =>
+  new Promise((resolve) => setTimeout(resolve, durationMs));
+
+const safeReadJsonFile = (filePath: string, maxBytes: number): unknown => {
+  const descriptor = fs.openSync(
+    filePath,
+    fs.constants.O_RDONLY | fs.constants.O_NOFOLLOW
+  );
+  try {
+    const stats = fs.fstatSync(descriptor);
+    if (!stats.isFile()) {
+      throw new Error("Telemetry record must be a regular file");
+    }
+    if (stats.size > maxBytes) {
+      throw new Error("Telemetry record exceeds its size limit");
+    }
+    return JSON.parse(fs.readFileSync(descriptor, "utf8")) as unknown;
+  } finally {
+    fs.closeSync(descriptor);
+  }
+};
+
+const readLockOwner = (lockDirectory: string): EventLockOwner | null => {
+  try {
+    const value = safeReadJsonFile(
+      path.join(lockDirectory, "owner.json"),
+      4096
+    );
+    if (
+      isRecord(value) &&
+      typeof value.token === "string" &&
+      typeof value.pid === "number" &&
+      Number.isSafeInteger(value.pid) &&
+      typeof value.hostname === "string" &&
+      isCanonicalTimestamp(value.createdAt)
+    ) {
+      return value as EventLockOwner;
+    }
+  } catch {
+    // A malformed young lock is retained until the conservative stale timeout.
+  }
+  return null;
+};
+
+const isProcessAlive = (pid: number): boolean => {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (error) {
+    return (error as NodeJS.ErrnoException).code === "EPERM";
+  }
+};
+
+const isEventLockStale = (
+  lockDirectory: string,
+  staleLockMs: number,
+  nowMs: number
+): boolean => {
+  const stats = fs.lstatSync(lockDirectory);
+  if (stats.isSymbolicLink() || !stats.isDirectory()) {
+    return false;
+  }
+  const owner = readLockOwner(lockDirectory);
+  if (!owner) {
+    return nowMs - stats.mtimeMs > staleLockMs;
+  }
+  if (owner.hostname === os.hostname()) {
+    return !isProcessAlive(owner.pid);
+  }
+  return nowMs - stats.mtimeMs > staleLockMs;
+};
+
+const breakStaleEventLock = (lockDirectory: string): boolean => {
+  const tombstone = `${lockDirectory}.stale-${
+    process.pid
+  }-${crypto.randomUUID()}`;
+  try {
+    fs.renameSync(lockDirectory, tombstone);
+    fs.rmSync(tombstone, { recursive: true, force: true });
+    return true;
+  } catch (error) {
+    const code = (error as NodeJS.ErrnoException).code;
+    if (code === "ENOENT" || code === "EEXIST") {
+      return false;
+    }
+    throw error;
+  }
+};
+
+const acquireEventLock = async (
+  eventsRoot: string,
+  options: Required<
+    Pick<
+      RecordResolveEventOptions,
+      "maxLockWaitMs" | "lockRetryIntervalMs" | "staleLockMs"
+    >
+  >,
+  now: () => number
+): Promise<EventLock | null> => {
+  const lockDirectory = path.join(eventsRoot, ".telemetry.lock");
+  const deadline = now() + options.maxLockWaitMs;
+
+  while (true) {
+    const token = crypto.randomUUID();
+    try {
+      fs.mkdirSync(lockDirectory);
+      const owner: EventLockOwner = {
+        token,
+        pid: process.pid,
+        hostname: os.hostname(),
+        createdAt: new Date(now()).toISOString(),
+      };
+      try {
+        fs.writeFileSync(
+          path.join(lockDirectory, "owner.json"),
+          `${JSON.stringify(owner)}\n`,
+          { encoding: "utf8", mode: 0o600 }
+        );
+      } catch (error) {
+        fs.rmSync(lockDirectory, { recursive: true, force: true });
+        throw error;
+      }
+      return { directory: lockDirectory, token };
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== "EEXIST") {
+        throw error;
+      }
+    }
+
+    try {
+      if (isEventLockStale(lockDirectory, options.staleLockMs, now())) {
+        breakStaleEventLock(lockDirectory);
+        continue;
+      }
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+        continue;
+      }
+      throw error;
+    }
+
+    if (now() >= deadline) {
+      return null;
+    }
+    await delay(options.lockRetryIntervalMs);
+  }
+};
+
+const releaseEventLock = (lock: EventLock): void => {
+  const owner = readLockOwner(lock.directory);
+  if (owner?.token === lock.token) {
+    fs.rmSync(lock.directory, { recursive: true, force: true });
+  }
+};
+
+const assertEventsRoot = (eventsRoot: string): void => {
+  const stats = fs.lstatSync(eventsRoot);
+  if (stats.isSymbolicLink() || !stats.isDirectory()) {
+    throw new Error("Telemetry root must be a real directory");
+  }
+};
+
+const eventFileNames = (eventsRoot: string): Array<[string, string]> => {
+  try {
+    assertEventsRoot(eventsRoot);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+      return [];
+    }
+    throw error;
+  }
+  const files: Array<[string, string]> = [];
+  for (const dayName of fs.readdirSync(eventsRoot)) {
+    if (!EVENT_DAY_PATTERN.test(dayName)) {
+      continue;
+    }
+    const dayDirectory = path.join(eventsRoot, dayName);
+    try {
+      const dayStats = fs.lstatSync(dayDirectory);
+      if (dayStats.isSymbolicLink() || !dayStats.isDirectory()) {
+        continue;
+      }
+      for (const fileName of fs.readdirSync(dayDirectory)) {
+        if (
+          EVENT_FILE_PATTERN.test(fileName) ||
+          EVENT_TEMP_FILE_PATTERN.test(fileName)
+        ) {
+          files.push([dayName, fileName]);
+        }
+      }
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== "ENOENT") {
+        throw error;
+      }
+    }
+  }
+  return files;
+};
+
+export const scanResolveEvents = (eventsRoot: string): ResolveEventScan => {
+  const events: StoredResolveEvent[] = [];
+  const invalid: InvalidResolveEvent[] = [];
+
+  for (const [dayName, fileName] of eventFileNames(eventsRoot)) {
+    const filePath = path.join(eventsRoot, dayName, fileName);
+    let sizeBytes = 0;
+    try {
+      const stats = fs.lstatSync(filePath);
+      sizeBytes = stats.size;
+      if (stats.isSymbolicLink() || !stats.isFile()) {
+        throw new Error("Telemetry record must be a regular file");
+      }
+      if (stats.size > RESOLVE_EVENT_MAX_BYTES) {
+        throw new Error("Telemetry record exceeds its size limit");
+      }
+      const event = parseResolveEvent(
+        safeReadJsonFile(filePath, RESOLVE_EVENT_MAX_BYTES)
+      );
+      const fileMatch = EVENT_FILE_PATTERN.exec(fileName);
+      if (
+        !fileMatch ||
+        getUtcDay(event.timestamp) !== dayName ||
+        getTimestampToken(event.timestamp) !== fileMatch[1]
+      ) {
+        throw new Error("Telemetry timestamp does not match its UTC path");
+      }
+      events.push({ event, filePath, sizeBytes: stats.size });
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+        continue;
+      }
+      invalid.push({
+        filePath,
+        sizeBytes,
+        reason:
+          error instanceof Error ? error.message : "Invalid telemetry record",
+      });
+    }
+  }
+
+  events.sort(
+    (left, right) =>
+      left.event.timestamp.localeCompare(right.event.timestamp) ||
+      left.filePath.localeCompare(right.filePath)
+  );
+  const validBytes = events.reduce((total, item) => total + item.sizeBytes, 0);
+  const invalidBytes = invalid.reduce(
+    (total, item) => total + item.sizeBytes,
+    0
+  );
+  return {
+    events,
+    invalid,
+    validBytes,
+    invalidBytes,
+    totalBytes: validBytes + invalidBytes,
+  };
+};
+
+const removeEvent = (eventsRoot: string, eventPath: string): void => {
+  if (!isPathInside(eventsRoot, eventPath)) {
+    throw new Error("Telemetry event escapes its managed root");
+  }
+  fs.unlinkSync(eventPath);
+};
+
+const removeEmptyDayDirectories = (eventsRoot: string): void => {
+  for (const dayName of fs.readdirSync(eventsRoot)) {
+    if (!EVENT_DAY_PATTERN.test(dayName)) {
+      continue;
+    }
+    const dayDirectory = path.join(eventsRoot, dayName);
+    try {
+      const stats = fs.lstatSync(dayDirectory);
+      if (
+        !stats.isSymbolicLink() &&
+        stats.isDirectory() &&
+        fs.readdirSync(dayDirectory).length === 0
+      ) {
+        fs.rmdirSync(dayDirectory);
+      }
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== "ENOENT") {
+        throw error;
+      }
+    }
+  }
+};
+
+const selectRetentionCandidates = (
+  scan: ResolveEventScan,
+  nowMs: number,
+  maximumSurvivors: number
+): ResolveEventPruneCandidate[] => {
+  const cutoffMs = nowMs - RETENTION_MS;
+  const expired = scan.events.filter(
+    ({ event }) => Date.parse(event.timestamp) < cutoffMs
+  );
+  const expiredPaths = new Set(expired.map(({ filePath }) => filePath));
+  const retained = scan.events.filter(
+    ({ filePath }) => !expiredPaths.has(filePath)
+  );
+  const excessCount = Math.max(0, retained.length - maximumSurvivors);
+  return [
+    ...scan.invalid.map(({ filePath, sizeBytes }) => ({
+      filePath,
+      timestamp: null,
+      sizeBytes,
+      reason: "invalid" as const,
+    })),
+    ...expired.map(({ event, filePath, sizeBytes }) => ({
+      filePath,
+      timestamp: event.timestamp,
+      sizeBytes,
+      reason: "expired" as const,
+    })),
+    ...retained.slice(0, excessCount).map(({ event, filePath, sizeBytes }) => ({
+      filePath,
+      timestamp: event.timestamp,
+      sizeBytes,
+      reason: "event-count" as const,
+    })),
+  ];
+};
+
+const applyRetention = (
+  eventsRoot: string,
+  candidates: readonly ResolveEventPruneCandidate[]
+): {
+  removed: ResolveEventPruneCandidate[];
+  removedCount: number;
+  removedBytes: number;
+} => {
+  const removed: ResolveEventPruneCandidate[] = [];
+  let removedCount = 0;
+  let removedBytes = 0;
+  for (const candidate of candidates) {
+    try {
+      removeEvent(eventsRoot, candidate.filePath);
+      removed.push(candidate);
+      removedCount += 1;
+      removedBytes += candidate.sizeBytes;
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== "ENOENT") {
+        throw error;
+      }
+    }
+  }
+  removeEmptyDayDirectories(eventsRoot);
+  return { removed, removedCount, removedBytes };
+};
+
+const validateEventInput = (
+  input: ResolveEventInput,
+  timestamp: string
+): ResolveEvent =>
+  parseResolveEvent({
+    schemaVersion: RESOLVE_EVENT_SCHEMA_VERSION,
+    timestamp,
+    ...input,
+  });
+
+const publishEvent = (
+  eventsRoot: string,
+  event: ResolveEvent,
+  randomUUID: () => string
+): string => {
+  const dayDirectory = path.join(eventsRoot, getUtcDay(event.timestamp));
+  ensureRealDirectoryTree(eventsRoot, dayDirectory);
+
+  const identifier = randomUUID().toLowerCase();
+  if (
+    !/^[a-f0-9]{8}-[a-f0-9]{4}-4[a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$/.test(
+      identifier
+    )
+  ) {
+    throw new Error("Telemetry event identifier must be a UUID v4");
+  }
+  const fileName = `${getTimestampToken(event.timestamp)}-${identifier}.json`;
+  const finalPath = path.join(dayDirectory, fileName);
+  const temporaryPath = path.join(
+    dayDirectory,
+    `.tmp-${process.pid}-${crypto.randomUUID()}`
+  );
+  const contents = `${JSON.stringify(event)}\n`;
+  if (Buffer.byteLength(contents) > RESOLVE_EVENT_MAX_BYTES) {
+    throw new Error("Telemetry record exceeds its size limit");
+  }
+  try {
+    fs.lstatSync(finalPath);
+    throw new Error("Telemetry event already exists");
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== "ENOENT") {
+      throw error;
+    }
+  }
+
+  let descriptor: number | null = null;
+  try {
+    descriptor = fs.openSync(
+      temporaryPath,
+      fs.constants.O_CREAT |
+        fs.constants.O_EXCL |
+        fs.constants.O_WRONLY |
+        fs.constants.O_NOFOLLOW,
+      0o600
+    );
+    fs.writeFileSync(descriptor, contents, "utf8");
+    fs.fsyncSync(descriptor);
+    fs.closeSync(descriptor);
+    descriptor = null;
+    fs.renameSync(temporaryPath, finalPath);
+    return finalPath;
+  } finally {
+    if (descriptor !== null) {
+      fs.closeSync(descriptor);
+    }
+    fs.rmSync(temporaryPath, { force: true });
+  }
+};
+
+export const recordResolveEvent = async (
+  providerRoot: string,
+  eventsRoot: string,
+  input: ResolveEventInput,
+  options: RecordResolveEventOptions = {}
+): Promise<RecordResolveEventResult> => {
+  try {
+    ensureRealDirectoryTree(providerRoot, eventsRoot);
+    const eventNowMs = options.nowMs ?? Date.now();
+    const timestamp = new Date(eventNowMs).toISOString();
+    const event = validateEventInput(input, timestamp);
+    const lock = await acquireEventLock(
+      eventsRoot,
+      {
+        maxLockWaitMs: options.maxLockWaitMs ?? 50,
+        lockRetryIntervalMs: options.lockRetryIntervalMs ?? 10,
+        staleLockMs: options.staleLockMs ?? 60_000,
+      },
+      Date.now
+    );
+    if (!lock) {
+      return { status: "lock-busy" };
+    }
+
+    try {
+      const candidates = selectRetentionCandidates(
+        scanResolveEvents(eventsRoot),
+        eventNowMs,
+        RESOLVE_EVENT_MAX_COUNT - 1
+      );
+      applyRetention(eventsRoot, candidates);
+      const filePath = publishEvent(
+        eventsRoot,
+        event,
+        options.randomUUID ?? crypto.randomUUID
+      );
+      return { status: "recorded", event, filePath };
+    } finally {
+      releaseEventLock(lock);
+    }
+  } catch (error) {
+    return {
+      status: "failed",
+      error:
+        error instanceof Error ? error : new Error("Telemetry write failed"),
+    };
+  }
+};
+
+export const pruneResolveEvents = async (
+  providerRoot: string,
+  eventsRoot: string,
+  options: PruneResolveEventsOptions = {}
+): Promise<PruneResolveEventsResult> => {
+  try {
+    if (!fs.existsSync(eventsRoot)) {
+      return {
+        status: "pruned",
+        candidates: [],
+        removed: [],
+        removedCount: 0,
+        removedBytes: 0,
+      };
+    }
+    ensureRealDirectoryTree(providerRoot, eventsRoot);
+    const nowMs = options.nowMs ?? Date.now();
+    const lock = await acquireEventLock(
+      eventsRoot,
+      {
+        maxLockWaitMs: options.maxLockWaitMs ?? 50,
+        lockRetryIntervalMs: options.lockRetryIntervalMs ?? 10,
+        staleLockMs: options.staleLockMs ?? 60_000,
+      },
+      Date.now
+    );
+    if (!lock) {
+      return { status: "lock-busy" };
+    }
+
+    try {
+      const candidates = selectRetentionCandidates(
+        scanResolveEvents(eventsRoot),
+        nowMs,
+        RESOLVE_EVENT_MAX_COUNT
+      );
+      const removed = options.dryRun
+        ? { removed: [], removedCount: 0, removedBytes: 0 }
+        : applyRetention(eventsRoot, candidates);
+      return { status: "pruned", candidates, ...removed };
+    } finally {
+      releaseEventLock(lock);
+    }
+  } catch (error) {
+    return {
+      status: "failed",
+      error:
+        error instanceof Error ? error : new Error("Telemetry prune failed"),
+    };
+  }
+};
+
+export const summarizeResolveEvents = (
+  events: readonly ResolveEvent[]
+): ResolveEventSummary => {
+  if (events.length > RESOLVE_EVENT_MAX_COUNT) {
+    throw new Error("Resolve event aggregate exceeds the retained event limit");
+  }
+  let hits = 0;
+  let misses = 0;
+  let errors = 0;
+  let lookupDurationMs = 0;
+  let estimatedTimeSavedMs = 0;
+  let hitsWithoutEstimate = 0;
+  let windowStart: string | null = null;
+  let windowEnd: string | null = null;
+
+  const addMetric = (total: number, value: number): number => {
+    const next = total + value;
+    if (!Number.isFinite(next) || !Number.isSafeInteger(Math.ceil(next))) {
+      throw new Error("Resolve event aggregate exceeds the safe numeric range");
+    }
+    return next;
+  };
+
+  for (const event of events) {
+    const validated = parseResolveEvent(event);
+    lookupDurationMs = addMetric(lookupDurationMs, validated.lookupDurationMs);
+    if (validated.outcome === "hit") {
+      hits += 1;
+      if (validated.estimatedTimeSavedMs === undefined) {
+        hitsWithoutEstimate += 1;
+      } else {
+        estimatedTimeSavedMs = addMetric(
+          estimatedTimeSavedMs,
+          validated.estimatedTimeSavedMs
+        );
+      }
+    } else if (validated.outcome === "miss") {
+      misses += 1;
+    } else {
+      errors += 1;
+    }
+    if (windowStart === null || validated.timestamp < windowStart) {
+      windowStart = validated.timestamp;
+    }
+    if (windowEnd === null || validated.timestamp > windowEnd) {
+      windowEnd = validated.timestamp;
+    }
+  }
+
+  const decisions = hits + misses;
+  return {
+    eventCount: events.length,
+    hits,
+    misses,
+    errors,
+    hitRate: decisions === 0 ? null : hits / decisions,
+    lookupDurationMs,
+    estimatedTimeSavedMs,
+    hitsWithoutEstimate,
+    windowStart,
+    windowEnd,
+  };
+};

--- a/src/cache/fingerprint.ts
+++ b/src/cache/fingerprint.ts
@@ -1,0 +1,142 @@
+import * as fs from "fs";
+import * as path from "path";
+import { createRequire } from "module";
+
+import {
+  normalizeRunProfile,
+  sanitizeFingerprintSources,
+  type FingerprintSnapshot,
+  type RawFingerprintSource,
+} from "./insight";
+import type { CachePlatform } from "./paths";
+
+type ExpoFingerprint = {
+  hash: string;
+  sources: RawFingerprintSource[];
+};
+
+type ExpoFingerprintModule = {
+  createFingerprintAsync: (
+    projectRoot: string,
+    options: { silent: true }
+  ) => Promise<ExpoFingerprint>;
+};
+
+export type ProjectFingerprintEngine = {
+  module: ExpoFingerprintModule;
+  version: string;
+  modulePath: string;
+};
+
+export type ProjectFingerprintCalculation = {
+  fingerprintHash: string;
+  snapshot: FingerprintSnapshot | null;
+};
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null && !Array.isArray(value);
+
+const hasControlCharacters = (value: string): boolean =>
+  Array.from(value).some((character) => {
+    const codePoint = character.codePointAt(0) ?? 0;
+    return codePoint <= 0x1f || codePoint === 0x7f;
+  });
+
+const readFingerprintPackageVersion = (packagePath: string): string => {
+  const descriptor = fs.openSync(
+    packagePath,
+    fs.constants.O_RDONLY | fs.constants.O_NOFOLLOW
+  );
+  let contents: string;
+  try {
+    const stats = fs.fstatSync(descriptor);
+    if (!stats.isFile() || stats.size > 64 * 1024) {
+      throw new Error("Invalid @expo/fingerprint package metadata");
+    }
+    contents = fs.readFileSync(descriptor, "utf8");
+  } finally {
+    fs.closeSync(descriptor);
+  }
+
+  const parsed: unknown = JSON.parse(contents);
+  if (
+    !isRecord(parsed) ||
+    parsed.name !== "@expo/fingerprint" ||
+    typeof parsed.version !== "string" ||
+    parsed.version.length === 0 ||
+    parsed.version.length > 128 ||
+    hasControlCharacters(parsed.version)
+  ) {
+    throw new Error("Invalid @expo/fingerprint package metadata");
+  }
+  return parsed.version;
+};
+
+export const loadProjectFingerprintEngine = (
+  projectRoot: string
+): ProjectFingerprintEngine => {
+  const projectRequire = createRequire(path.join(projectRoot, "package.json"));
+  const modulePath = projectRequire.resolve("@expo/fingerprint");
+  const packagePath = projectRequire.resolve("@expo/fingerprint/package.json");
+  const loaded: unknown = projectRequire(modulePath);
+
+  if (
+    !isRecord(loaded) ||
+    typeof loaded.createFingerprintAsync !== "function"
+  ) {
+    throw new Error("Project @expo/fingerprint has an unsupported API");
+  }
+
+  return {
+    module: loaded as ExpoFingerprintModule,
+    version: readFingerprintPackageVersion(packagePath),
+    modulePath,
+  };
+};
+
+export const calculateProjectFingerprint = async ({
+  projectRoot,
+  platform,
+  runOptions,
+  now = () => new Date(),
+}: {
+  projectRoot: string;
+  platform: CachePlatform;
+  runOptions: unknown;
+  now?: () => Date;
+}): Promise<ProjectFingerprintCalculation> => {
+  const engine = loadProjectFingerprintEngine(projectRoot);
+  const fingerprint = await engine.module.createFingerprintAsync(projectRoot, {
+    silent: true,
+  });
+
+  if (
+    !isRecord(fingerprint) ||
+    typeof fingerprint.hash !== "string" ||
+    fingerprint.hash.length === 0 ||
+    fingerprint.hash.length > 256 ||
+    hasControlCharacters(fingerprint.hash) ||
+    !Array.isArray(fingerprint.sources)
+  ) {
+    throw new Error("Project @expo/fingerprint returned malformed output");
+  }
+
+  const sources = sanitizeFingerprintSources(
+    projectRoot,
+    fingerprint.sources as RawFingerprintSource[]
+  );
+  return {
+    fingerprintHash: fingerprint.hash,
+    snapshot:
+      sources === null
+        ? null
+        : {
+            platform,
+            fingerprintHash: fingerprint.hash,
+            capturedAt: now().toISOString(),
+            fingerprintEngineVersion: engine.version,
+            runProfile: normalizeRunProfile(platform, runOptions),
+            sources,
+          },
+  };
+};

--- a/src/cache/insight.ts
+++ b/src/cache/insight.ts
@@ -1,0 +1,775 @@
+import * as crypto from "crypto";
+import * as fs from "fs";
+import * as path from "path";
+
+import { isPathInside } from "./filesystem";
+import type { CachePlatform } from "./paths";
+
+export const INSIGHT_SCHEMA_VERSION = 1;
+export const INSIGHT_FILENAME = "insight.json";
+export const MAX_INSIGHT_BYTES = 1024 * 1024;
+export const MAX_INSIGHT_SOURCES = 10_000;
+export const MAX_INSIGHT_DISPLAY_PATH_LENGTH = 256;
+
+const MAX_IDENTITY_LENGTH = 16_384;
+const MAX_HASH_LENGTH = 256;
+const MAX_ENGINE_VERSION_LENGTH = 128;
+const MAX_PROFILE_VALUE_LENGTH = 256;
+
+export const EVIDENCE_CATEGORIES = [
+  "expo-config",
+  "native-dependencies",
+  "native-project",
+  "project-metadata",
+  "other",
+] as const;
+
+export type EvidenceCategory = (typeof EVIDENCE_CATEGORIES)[number];
+
+export type IosRunProfile = {
+  configuration: "Debug" | "Release";
+  scheme: string;
+};
+
+export type AndroidRunProfile = {
+  variant: string;
+  allArch: boolean;
+};
+
+export type RunProfile = IosRunProfile | AndroidRunProfile;
+
+export type RawFingerprintSource = {
+  type: "file" | "dir" | "contents";
+  hash: string | null;
+  reasons?: unknown;
+  filePath?: unknown;
+  overrideHashKey?: unknown;
+  id?: unknown;
+  contents?: unknown;
+  debugInfo?: unknown;
+};
+
+export type InsightSource = {
+  type: RawFingerprintSource["type"];
+  comparatorHash: string;
+  occurrence: number;
+  displayPath?: string;
+  digest: string | null;
+  categories: EvidenceCategory[];
+};
+
+export type FingerprintSnapshot = {
+  platform: CachePlatform;
+  fingerprintHash: string;
+  capturedAt: string;
+  fingerprintEngineVersion: string;
+  runProfile: RunProfile;
+  sources: InsightSource[];
+};
+
+export type ArtifactReadyEstimate = {
+  durationMs: number;
+  method: "artifact-mtime-v1";
+};
+
+export type CacheInsight = FingerprintSnapshot & {
+  schemaVersion: 1;
+  entryId: string;
+  artifactReadyEstimate?: ArtifactReadyEstimate;
+};
+
+export type InsightDiffOperation = "added" | "removed" | "changed";
+
+export type InsightDiffItem = {
+  operation: InsightDiffOperation;
+  category: EvidenceCategory;
+  before?: InsightSource;
+  after?: InsightSource;
+};
+
+export type InsightDiff = {
+  items: InsightDiffItem[];
+  added: number;
+  removed: number;
+  changed: number;
+  total: number;
+  groups: Array<{ category: EvidenceCategory; count: number }>;
+};
+
+export type InsightCandidate = {
+  insight: CacheInsight;
+  lastAccessAt?: string | null;
+  createdAt: string;
+  entryId: string;
+};
+
+export type ClosestInsightResult =
+  | {
+      status: "match";
+      candidate: InsightCandidate;
+      diff: InsightDiff;
+    }
+  | {
+      status:
+        | "no-compatible-profile"
+        | "fingerprint-engine-mismatch"
+        | "no-candidate";
+      candidate: null;
+      diff: null;
+    };
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null && !Array.isArray(value);
+
+const hasControlCharacters = (value: string): boolean =>
+  Array.from(value).some((character) => {
+    const codePoint = character.codePointAt(0) ?? 0;
+    return codePoint <= 0x1f || codePoint === 0x7f;
+  });
+
+const hasOnlyKeys = (
+  value: Record<string, unknown>,
+  allowedKeys: readonly string[]
+): boolean => Object.keys(value).every((key) => allowedKeys.includes(key));
+
+const isBoundedString = (
+  value: unknown,
+  maximumLength: number,
+  allowEmpty = false
+): value is string =>
+  typeof value === "string" &&
+  (allowEmpty || value.length > 0) &&
+  value.length <= maximumLength &&
+  !hasControlCharacters(value);
+
+const isIsoTimestamp = (value: unknown): value is string =>
+  isBoundedString(value, 64) &&
+  Number.isFinite(Date.parse(value)) &&
+  new Date(value).toISOString() === value;
+
+const isCachePlatform = (value: unknown): value is CachePlatform =>
+  value === "android" || value === "ios";
+
+const isEvidenceCategory = (value: unknown): value is EvidenceCategory =>
+  EVIDENCE_CATEGORIES.includes(value as EvidenceCategory);
+
+const normalizeProfileValue = (value: unknown, fallback: string): string =>
+  isBoundedString(value, MAX_PROFILE_VALUE_LENGTH) ? value : fallback;
+
+export const normalizeRunProfile = (
+  platform: CachePlatform,
+  runOptions: unknown
+): RunProfile => {
+  const options = isRecord(runOptions) ? runOptions : {};
+
+  if (platform === "ios") {
+    return {
+      configuration: options.configuration === "Release" ? "Release" : "Debug",
+      scheme: normalizeProfileValue(options.scheme, "default"),
+    };
+  }
+
+  return {
+    variant: normalizeProfileValue(options.variant, "debug"),
+    allArch: options.allArch === true,
+  };
+};
+
+export const runProfilesEqual = (
+  platform: CachePlatform,
+  left: RunProfile,
+  right: RunProfile
+): boolean => {
+  if (platform === "ios") {
+    return (
+      "configuration" in left &&
+      "configuration" in right &&
+      left.configuration === right.configuration &&
+      left.scheme === right.scheme
+    );
+  }
+
+  return (
+    "variant" in left &&
+    "variant" in right &&
+    left.variant === right.variant &&
+    left.allArch === right.allArch
+  );
+};
+
+const categorizeReason = (reason: string): EvidenceCategory => {
+  if (
+    reason === "expoConfig" ||
+    reason === "expoConfigPlugins" ||
+    reason === "expoConfigExternalFile"
+  ) {
+    return "expo-config";
+  }
+  if (
+    reason.startsWith("expoAutolinking") ||
+    reason.startsWith("rncoreAutolinking") ||
+    reason.startsWith("package:")
+  ) {
+    return "native-dependencies";
+  }
+  if (reason === "bareNativeDir") {
+    return "native-project";
+  }
+  if (
+    reason === "patchPackage" ||
+    reason === "expoCNGPatches" ||
+    reason === "easBuild" ||
+    reason === "bareGitIgnore" ||
+    reason.startsWith("packageJson:")
+  ) {
+    return "project-metadata";
+  }
+  return "other";
+};
+
+const categoriesForReasons = (reasons: unknown): EvidenceCategory[] => {
+  if (!Array.isArray(reasons)) {
+    return ["other"];
+  }
+
+  const categories = new Set<EvidenceCategory>();
+  for (const reason of reasons) {
+    if (typeof reason === "string") {
+      categories.add(categorizeReason(reason));
+    }
+  }
+
+  if (categories.size === 0) {
+    categories.add("other");
+  }
+  return EVIDENCE_CATEGORIES.filter((category) => categories.has(category));
+};
+
+const getComparatorIdentity = (source: RawFingerprintSource): string | null => {
+  if (source.type === "contents") {
+    return isBoundedString(source.id, MAX_IDENTITY_LENGTH) ? source.id : null;
+  }
+
+  const identity =
+    typeof source.overrideHashKey === "string"
+      ? source.overrideHashKey
+      : source.filePath;
+  return isBoundedString(identity, MAX_IDENTITY_LENGTH) ? identity : null;
+};
+
+const getSafeDisplayPath = (
+  projectRoot: string,
+  source: RawFingerprintSource
+): string | undefined => {
+  if (
+    source.type === "contents" ||
+    !isBoundedString(source.filePath, MAX_IDENTITY_LENGTH)
+  ) {
+    return undefined;
+  }
+
+  const resolvedRoot = path.resolve(projectRoot);
+  const candidate = path.resolve(resolvedRoot, source.filePath);
+  if (!isPathInside(resolvedRoot, candidate)) {
+    return undefined;
+  }
+
+  try {
+    const rootRealPath = fs.realpathSync(resolvedRoot);
+    const candidateStats = fs.lstatSync(candidate);
+    if (candidateStats.isSymbolicLink()) {
+      return undefined;
+    }
+    if (!isPathInside(rootRealPath, fs.realpathSync(candidate))) {
+      return undefined;
+    }
+  } catch {
+    return undefined;
+  }
+
+  const relative = path.relative(resolvedRoot, candidate);
+  if (
+    relative.length === 0 ||
+    relative.length > MAX_INSIGHT_DISPLAY_PATH_LENGTH ||
+    relative === ".." ||
+    relative.startsWith(`..${path.sep}`) ||
+    path.isAbsolute(relative) ||
+    hasControlCharacters(relative)
+  ) {
+    return undefined;
+  }
+
+  return relative.split(path.sep).join("/");
+};
+
+const normalizeDigest = (hash: unknown): string | null | undefined => {
+  if (hash === null) {
+    return null;
+  }
+  return typeof hash === "string" &&
+    hash.length > 0 &&
+    hash.length <= MAX_HASH_LENGTH &&
+    /^[a-fA-F0-9]+$/.test(hash)
+    ? hash.toLowerCase()
+    : undefined;
+};
+
+export const sanitizeFingerprintSources = (
+  projectRoot: string,
+  sources: readonly RawFingerprintSource[]
+): InsightSource[] | null => {
+  if (sources.length > MAX_INSIGHT_SOURCES) {
+    return null;
+  }
+
+  const occurrences = new Map<string, number>();
+  const sanitized: InsightSource[] = [];
+
+  for (const source of sources) {
+    if (
+      !isRecord(source) ||
+      (source.type !== "file" &&
+        source.type !== "dir" &&
+        source.type !== "contents")
+    ) {
+      return null;
+    }
+
+    const identity = getComparatorIdentity(source);
+    if (identity === null) {
+      return null;
+    }
+
+    const comparatorHash = crypto
+      .createHash("sha256")
+      .update(source.type)
+      .update("\0")
+      .update(identity)
+      .digest("hex");
+    const occurrenceKey = `${source.type}\0${comparatorHash}`;
+    const occurrence = occurrences.get(occurrenceKey) ?? 0;
+    occurrences.set(occurrenceKey, occurrence + 1);
+
+    const displayPath = getSafeDisplayPath(projectRoot, source);
+    const digest = normalizeDigest(source.hash);
+    if (digest === undefined) {
+      return null;
+    }
+    sanitized.push({
+      type: source.type,
+      comparatorHash,
+      occurrence,
+      ...(displayPath === undefined ? {} : { displayPath }),
+      digest,
+      categories: categoriesForReasons(source.reasons),
+    });
+  }
+
+  return sanitized;
+};
+
+const isRunProfile = (
+  platform: CachePlatform,
+  value: unknown
+): value is RunProfile => {
+  if (!isRecord(value)) {
+    return false;
+  }
+
+  if (platform === "ios") {
+    return (
+      hasOnlyKeys(value, ["configuration", "scheme"]) &&
+      (value.configuration === "Debug" || value.configuration === "Release") &&
+      isBoundedString(value.scheme, MAX_PROFILE_VALUE_LENGTH)
+    );
+  }
+
+  return (
+    hasOnlyKeys(value, ["variant", "allArch"]) &&
+    isBoundedString(value.variant, MAX_PROFILE_VALUE_LENGTH) &&
+    typeof value.allArch === "boolean"
+  );
+};
+
+const isInsightSource = (value: unknown): value is InsightSource => {
+  if (!isRecord(value)) {
+    return false;
+  }
+  const categories = value.categories;
+  if (
+    !Array.isArray(categories) ||
+    categories.length < 1 ||
+    categories.length > EVIDENCE_CATEGORIES.length ||
+    !categories.every(isEvidenceCategory) ||
+    new Set(categories).size !== categories.length ||
+    !EVIDENCE_CATEGORIES.filter((category) =>
+      categories.includes(category)
+    ).every((category, index) => category === categories[index])
+  ) {
+    return false;
+  }
+  const allowedKeys = [
+    "type",
+    "comparatorHash",
+    "occurrence",
+    "displayPath",
+    "digest",
+    "categories",
+  ];
+  const displayPath = value.displayPath;
+  const normalizedDisplayPath =
+    typeof displayPath === "string" ? path.posix.normalize(displayPath) : null;
+  return (
+    hasOnlyKeys(value, allowedKeys) &&
+    (value.type === "file" ||
+      value.type === "dir" ||
+      value.type === "contents") &&
+    typeof value.comparatorHash === "string" &&
+    /^[a-f0-9]{64}$/.test(value.comparatorHash) &&
+    Number.isSafeInteger(value.occurrence) &&
+    (value.occurrence as number) >= 0 &&
+    (displayPath === undefined ||
+      (isBoundedString(displayPath, MAX_INSIGHT_DISPLAY_PATH_LENGTH) &&
+        !displayPath.includes("\\") &&
+        !path.posix.isAbsolute(displayPath) &&
+        normalizedDisplayPath === displayPath &&
+        displayPath !== "." &&
+        displayPath !== ".." &&
+        !displayPath.startsWith("../"))) &&
+    (value.digest === null ||
+      (typeof value.digest === "string" &&
+        value.digest.length > 0 &&
+        value.digest.length <= MAX_HASH_LENGTH &&
+        /^[a-f0-9]+$/.test(value.digest)))
+  );
+};
+
+const isArtifactReadyEstimate = (
+  value: unknown
+): value is ArtifactReadyEstimate =>
+  isRecord(value) &&
+  hasOnlyKeys(value, ["durationMs", "method"]) &&
+  typeof value.durationMs === "number" &&
+  Number.isSafeInteger(value.durationMs) &&
+  value.durationMs >= 0 &&
+  value.durationMs <= 6 * 60 * 60 * 1000 &&
+  value.method === "artifact-mtime-v1";
+
+export const isCacheInsight = (value: unknown): value is CacheInsight => {
+  if (!isRecord(value)) {
+    return false;
+  }
+
+  const allowedKeys = [
+    "schemaVersion",
+    "platform",
+    "entryId",
+    "fingerprintHash",
+    "capturedAt",
+    "fingerprintEngineVersion",
+    "runProfile",
+    "sources",
+    "artifactReadyEstimate",
+  ];
+  if (
+    !hasOnlyKeys(value, allowedKeys) ||
+    value.schemaVersion !== INSIGHT_SCHEMA_VERSION ||
+    !isCachePlatform(value.platform) ||
+    typeof value.entryId !== "string" ||
+    !/^[a-f0-9]{64}$/.test(value.entryId) ||
+    !isBoundedString(value.fingerprintHash, MAX_HASH_LENGTH) ||
+    !isIsoTimestamp(value.capturedAt) ||
+    !isBoundedString(
+      value.fingerprintEngineVersion,
+      MAX_ENGINE_VERSION_LENGTH
+    ) ||
+    !isRunProfile(value.platform, value.runProfile) ||
+    !Array.isArray(value.sources) ||
+    value.sources.length > MAX_INSIGHT_SOURCES ||
+    !value.sources.every(isInsightSource) ||
+    (value.artifactReadyEstimate !== undefined &&
+      !isArtifactReadyEstimate(value.artifactReadyEstimate))
+  ) {
+    return false;
+  }
+
+  const occurrences = new Map<string, number>();
+  for (const source of value.sources) {
+    const key = `${source.type}\0${source.comparatorHash}`;
+    const expected = occurrences.get(key) ?? 0;
+    if (source.occurrence !== expected) {
+      return false;
+    }
+    occurrences.set(key, expected + 1);
+  }
+
+  return true;
+};
+
+export const createCacheInsight = (
+  snapshot: FingerprintSnapshot,
+  entryId: string,
+  artifactReadyEstimate?: ArtifactReadyEstimate
+): CacheInsight => {
+  const insight: CacheInsight = {
+    schemaVersion: INSIGHT_SCHEMA_VERSION,
+    ...snapshot,
+    entryId,
+    ...(artifactReadyEstimate === undefined ? {} : { artifactReadyEstimate }),
+  };
+  if (!isCacheInsight(insight)) {
+    throw new Error("Could not create a valid cache insight");
+  }
+  if (Buffer.byteLength(JSON.stringify(insight), "utf8") > MAX_INSIGHT_BYTES) {
+    throw new Error("Cache insight exceeds the 1 MiB limit");
+  }
+  return insight;
+};
+
+export const serializeCacheInsight = (insight: CacheInsight): string => {
+  if (!isCacheInsight(insight)) {
+    throw new Error("Cannot serialize a malformed cache insight");
+  }
+  const serialized = `${JSON.stringify(insight, null, 2)}\n`;
+  if (Buffer.byteLength(serialized, "utf8") > MAX_INSIGHT_BYTES) {
+    throw new Error("Cache insight exceeds the 1 MiB limit");
+  }
+  return serialized;
+};
+
+export const writeInsightAtomically = (
+  entryDirectory: string,
+  insight: CacheInsight
+): void => {
+  const serialized = serializeCacheInsight(insight);
+  const finalPath = path.join(entryDirectory, INSIGHT_FILENAME);
+  const temporaryPath = path.join(
+    entryDirectory,
+    `.insight-${process.pid}-${crypto.randomUUID()}.tmp`
+  );
+  let descriptor: number | undefined;
+
+  try {
+    try {
+      fs.lstatSync(finalPath);
+      throw new Error("Cache insight already exists");
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== "ENOENT") {
+        throw error;
+      }
+    }
+
+    descriptor = fs.openSync(
+      temporaryPath,
+      fs.constants.O_CREAT |
+        fs.constants.O_EXCL |
+        fs.constants.O_WRONLY |
+        fs.constants.O_NOFOLLOW,
+      0o600
+    );
+    fs.writeFileSync(descriptor, serialized, "utf8");
+    fs.fsyncSync(descriptor);
+    fs.closeSync(descriptor);
+    descriptor = undefined;
+    fs.renameSync(temporaryPath, finalPath);
+  } catch (error) {
+    if (descriptor !== undefined) {
+      fs.closeSync(descriptor);
+    }
+    try {
+      fs.unlinkSync(temporaryPath);
+    } catch (cleanupError) {
+      if ((cleanupError as NodeJS.ErrnoException).code !== "ENOENT") {
+        // Preserve the original write error.
+      }
+    }
+    throw error;
+  }
+};
+
+export const readInsight = (entryDirectory: string): CacheInsight | null => {
+  const insightPath = path.join(entryDirectory, INSIGHT_FILENAME);
+  let descriptor: number;
+  try {
+    descriptor = fs.openSync(
+      insightPath,
+      fs.constants.O_RDONLY | fs.constants.O_NOFOLLOW
+    );
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+      return null;
+    }
+    throw error;
+  }
+
+  let contents: string;
+  try {
+    const stats = fs.fstatSync(descriptor);
+    if (!stats.isFile()) {
+      throw new Error("Cache insight must be a regular file");
+    }
+    if (stats.size > MAX_INSIGHT_BYTES) {
+      throw new Error("Cache insight exceeds the 1 MiB limit");
+    }
+    contents = fs.readFileSync(descriptor, "utf8");
+  } finally {
+    fs.closeSync(descriptor);
+  }
+
+  const parsed: unknown = JSON.parse(contents);
+  if (!isCacheInsight(parsed)) {
+    throw new Error("Unsupported or malformed cache insight");
+  }
+  return parsed;
+};
+
+const sourceKey = (source: InsightSource): string =>
+  `${source.type}\0${source.comparatorHash}\0${source.occurrence}`;
+
+const primaryCategory = (
+  before: InsightSource | undefined,
+  after: InsightSource | undefined
+): EvidenceCategory => {
+  const categories = new Set([
+    ...(before?.categories ?? []),
+    ...(after?.categories ?? []),
+  ]);
+  return (
+    EVIDENCE_CATEGORIES.find((category) => categories.has(category)) ?? "other"
+  );
+};
+
+export const diffInsights = (
+  before: Pick<CacheInsight, "sources">,
+  after: Pick<CacheInsight, "sources">
+): InsightDiff => {
+  const beforeByKey = new Map(
+    before.sources.map((source) => [sourceKey(source), source])
+  );
+  const afterByKey = new Map(
+    after.sources.map((source) => [sourceKey(source), source])
+  );
+  const items: InsightDiffItem[] = [];
+
+  for (const source of before.sources) {
+    const key = sourceKey(source);
+    const next = afterByKey.get(key);
+    if (next === undefined) {
+      items.push({
+        operation: "removed",
+        category: primaryCategory(source, undefined),
+        before: source,
+      });
+    } else if (source.digest !== next.digest) {
+      items.push({
+        operation: "changed",
+        category: primaryCategory(source, next),
+        before: source,
+        after: next,
+      });
+    }
+  }
+
+  for (const source of after.sources) {
+    if (!beforeByKey.has(sourceKey(source))) {
+      items.push({
+        operation: "added",
+        category: primaryCategory(undefined, source),
+        after: source,
+      });
+    }
+  }
+
+  const groups = EVIDENCE_CATEGORIES.map((category) => ({
+    category,
+    count: items.filter((item) => item.category === category).length,
+  }))
+    .filter((group) => group.count > 0)
+    .sort(
+      (left, right) =>
+        right.count - left.count ||
+        EVIDENCE_CATEGORIES.indexOf(left.category) -
+          EVIDENCE_CATEGORIES.indexOf(right.category)
+    );
+  const added = items.filter((item) => item.operation === "added").length;
+  const removed = items.filter((item) => item.operation === "removed").length;
+  const changed = items.filter((item) => item.operation === "changed").length;
+
+  return {
+    items,
+    added,
+    removed,
+    changed,
+    total: added + removed + changed,
+    groups,
+  };
+};
+
+export const getTopEvidenceGroups = (
+  diff: Pick<InsightDiff, "groups">
+): InsightDiff["groups"] => diff.groups.slice(0, 3);
+
+const timestampValue = (value: string | null | undefined): number => {
+  const parsed =
+    value === null || value === undefined ? Number.NaN : Date.parse(value);
+  return Number.isFinite(parsed) ? parsed : 0;
+};
+
+export const selectClosestInsight = (
+  current: FingerprintSnapshot,
+  candidates: readonly InsightCandidate[]
+): ClosestInsightResult => {
+  if (candidates.length === 0) {
+    return { status: "no-candidate", candidate: null, diff: null };
+  }
+
+  const profileCandidates = candidates.filter(
+    (candidate) =>
+      candidate.insight.platform === current.platform &&
+      runProfilesEqual(
+        current.platform,
+        candidate.insight.runProfile,
+        current.runProfile
+      )
+  );
+  if (profileCandidates.length === 0) {
+    return {
+      status: "no-compatible-profile",
+      candidate: null,
+      diff: null,
+    };
+  }
+
+  const engineCandidates = profileCandidates.filter(
+    (candidate) =>
+      candidate.insight.fingerprintEngineVersion ===
+      current.fingerprintEngineVersion
+  );
+  if (engineCandidates.length === 0) {
+    return {
+      status: "fingerprint-engine-mismatch",
+      candidate: null,
+      diff: null,
+    };
+  }
+
+  const ranked = engineCandidates.map((candidate) => ({
+    candidate,
+    diff: diffInsights(candidate.insight, current),
+  }));
+  ranked.sort(
+    (left, right) =>
+      left.diff.total - right.diff.total ||
+      timestampValue(right.candidate.lastAccessAt) -
+        timestampValue(left.candidate.lastAccessAt) ||
+      timestampValue(right.candidate.createdAt) -
+        timestampValue(left.candidate.createdAt) ||
+      left.candidate.entryId.localeCompare(right.candidate.entryId)
+  );
+
+  const closest = ranked[0];
+  if (closest === undefined) {
+    return { status: "no-candidate", candidate: null, diff: null };
+  }
+  return { status: "match", ...closest };
+};

--- a/src/cache/paths.ts
+++ b/src/cache/paths.ts
@@ -11,6 +11,7 @@ export type CachePaths = {
   locksRoot: string;
   quarantineRoot: string;
   accessRoot: string;
+  eventsRoot: string;
   stateRoot: string;
   trashRoot: string;
 };
@@ -27,6 +28,7 @@ export const getCachePaths = (projectRoot: string): CachePaths => {
     locksRoot: path.join(providerRoot, "locks"),
     quarantineRoot: path.join(providerRoot, "quarantine"),
     accessRoot: path.join(providerRoot, "access"),
+    eventsRoot: path.join(providerRoot, "events"),
     stateRoot: path.join(providerRoot, "state"),
     trashRoot: path.join(providerRoot, "trash"),
   };

--- a/src/cache/store.ts
+++ b/src/cache/store.ts
@@ -12,6 +12,11 @@ import {
   pathExists,
 } from "./filesystem";
 import { inspectArtifact } from "./integrity";
+import {
+  INSIGHT_FILENAME,
+  writeInsightAtomically,
+  type CacheInsight,
+} from "./insight";
 import { acquireEntryLock, releaseEntryLock } from "./lock";
 import { CACHE_SCHEMA_VERSION, CacheManifest, writeManifest } from "./manifest";
 import {
@@ -29,6 +34,24 @@ type CacheIdentity = {
   platform: CachePlatform;
   fingerprintHash: string;
 };
+
+export type CacheMissReason =
+  | "not-found"
+  | "corrupt"
+  | "lock-busy"
+  | "unsafe-legacy-path"
+  | "legacy-invalid";
+
+export type CacheResolveResult =
+  | {
+      outcome: "hit";
+      path: string;
+      source: "versioned" | "legacy";
+    }
+  | {
+      outcome: "miss";
+      reason: CacheMissReason;
+    };
 
 const getPackageVersion = (): string => {
   try {
@@ -99,15 +122,16 @@ const isLegacyArtifactValid = (
   }
 };
 
-export const resolveCacheEntry = async ({
+export const resolveCacheEntryDetailed = async ({
   projectRoot,
   platform,
   fingerprintHash,
-}: CacheIdentity): Promise<string | null> => {
+}: CacheIdentity): Promise<CacheResolveResult> => {
   const managedProjectRoot = fs.realpathSync(projectRoot);
   const paths = getCachePaths(managedProjectRoot);
   const entryId = getEntryId(platform, fingerprintHash);
   const entryDirectory = getEntryDirectory(paths, platform, entryId);
+  let versionedMissReason: CacheMissReason | null = null;
 
   if (pathExists(entryDirectory)) {
     assertProviderRoot(managedProjectRoot, paths.providerRoot);
@@ -145,26 +169,53 @@ export const resolveCacheEntry = async ({
           } catch (error) {
             console.warn("Could not update cache access metadata", error);
           }
-          return revalidation.artifactPath;
+          return {
+            outcome: "hit",
+            path: revalidation.artifactPath,
+            source: "versioned",
+          };
         }
       } finally {
         releaseEntryLock(lock);
       }
+      versionedMissReason = "corrupt";
+    } else {
+      versionedMissReason = "lock-busy";
     }
   }
 
   const legacyPath = getLegacyArtifactPath(paths, platform, fingerprintHash);
-  if (legacyPath && isLegacyArtifactValid(legacyPath, platform)) {
+  if (!legacyPath) {
+    return {
+      outcome: "miss",
+      reason: versionedMissReason ?? "unsafe-legacy-path",
+    };
+  }
+  if (isLegacyArtifactValid(legacyPath, platform)) {
     console.warn(`Using unverified legacy ${platform} cache entry`);
-    return legacyPath;
+    return { outcome: "hit", path: legacyPath, source: "legacy" };
+  }
+  if (pathExists(legacyPath)) {
+    return {
+      outcome: "miss",
+      reason: versionedMissReason ?? "legacy-invalid",
+    };
   }
 
-  return null;
+  return { outcome: "miss", reason: versionedMissReason ?? "not-found" };
+};
+
+export const resolveCacheEntry = async (
+  identity: CacheIdentity
+): Promise<string | null> => {
+  const result = await resolveCacheEntryDetailed(identity);
+  return result.outcome === "hit" ? result.path : null;
 };
 
 export const uploadCacheEntry = async (
   { projectRoot, platform, fingerprintHash }: CacheIdentity,
-  buildPath: string
+  buildPath: string,
+  options: { insight?: CacheInsight } = {}
 ): Promise<string | null> => {
   validateSourceArtifact(buildPath, platform);
 
@@ -243,6 +294,27 @@ export const uploadCacheEntry = async (
       },
     };
     writeManifest(stagingDirectory, manifest);
+    if (options.insight) {
+      try {
+        if (
+          options.insight.platform !== platform ||
+          options.insight.fingerprintHash !== fingerprintHash ||
+          options.insight.entryId !== entryId
+        ) {
+          throw new Error("Cache insight identity does not match the entry");
+        }
+        writeInsightAtomically(stagingDirectory, options.insight);
+      } catch (error) {
+        try {
+          fs.rmSync(path.join(stagingDirectory, INSIGHT_FILENAME), {
+            force: true,
+          });
+        } catch {
+          // Diagnostic metadata must never block artifact publication.
+        }
+        console.warn("Could not persist cache insight", error);
+      }
+    }
 
     const stagedValidation = validateEntry(
       stagingDirectory,

--- a/src/cache/timing.ts
+++ b/src/cache/timing.ts
@@ -1,0 +1,119 @@
+import * as fs from "fs";
+import * as path from "path";
+
+import type { CachePlatform } from "./paths";
+
+export const ARTIFACT_MTIME_METHOD = "artifact-mtime-v1" as const;
+export const MAX_ARTIFACT_READY_DURATION_MS = 6 * 60 * 60 * 1000;
+export const ARTIFACT_CLOCK_TOLERANCE_MS = 2000;
+
+export type ArtifactReadyEstimate = {
+  durationMs: number;
+  method: typeof ARTIFACT_MTIME_METHOD;
+};
+
+type ArtifactReadyEstimateInput = {
+  artifactPath: string;
+  platform: CachePlatform;
+  missStartedAtMs: number;
+  uploadObservedAtMs: number;
+};
+
+const newestRegularFileMtime = (directory: string): number | null => {
+  let newest: number | null = null;
+  const pending = [directory];
+  let visited = 0;
+
+  while (pending.length > 0) {
+    const current = pending.pop()!;
+    for (const child of fs.readdirSync(current)) {
+      visited += 1;
+      if (visited > 100_000) {
+        throw new Error("Artifact contains too many filesystem entries");
+      }
+      const candidate = path.join(current, child);
+      const stats = fs.lstatSync(candidate);
+      if (stats.isSymbolicLink()) {
+        continue;
+      }
+      if (stats.isDirectory()) {
+        pending.push(candidate);
+      } else if (stats.isFile()) {
+        newest =
+          newest === null ? stats.mtimeMs : Math.max(newest, stats.mtimeMs);
+      }
+    }
+  }
+  return newest;
+};
+
+export const estimateArtifactReadyDuration = (
+  input: ArtifactReadyEstimateInput
+): ArtifactReadyEstimate | null => {
+  try {
+    if (
+      !Number.isFinite(input.missStartedAtMs) ||
+      !Number.isFinite(input.uploadObservedAtMs) ||
+      input.uploadObservedAtMs < input.missStartedAtMs
+    ) {
+      return null;
+    }
+    const artifactStats = fs.lstatSync(input.artifactPath);
+    if (artifactStats.isSymbolicLink()) {
+      return null;
+    }
+
+    let artifactMtimeMs: number | null;
+    if (input.platform === "android") {
+      artifactMtimeMs = artifactStats.isFile() ? artifactStats.mtimeMs : null;
+    } else {
+      artifactMtimeMs = artifactStats.isDirectory()
+        ? newestRegularFileMtime(input.artifactPath)
+        : null;
+    }
+    if (artifactMtimeMs === null || !Number.isFinite(artifactMtimeMs)) {
+      return null;
+    }
+
+    const rawDurationMs = artifactMtimeMs - input.missStartedAtMs;
+    if (
+      rawDurationMs < 0 ||
+      rawDurationMs > MAX_ARTIFACT_READY_DURATION_MS ||
+      artifactMtimeMs > input.uploadObservedAtMs + ARTIFACT_CLOCK_TOLERANCE_MS
+    ) {
+      return null;
+    }
+    const durationMs = Math.round(rawDurationMs);
+    return { durationMs, method: ARTIFACT_MTIME_METHOD };
+  } catch {
+    return null;
+  }
+};
+
+export const monotonicNow = (): bigint => process.hrtime.bigint();
+
+export const elapsedMilliseconds = (
+  startedAt: bigint,
+  finishedAt: bigint = monotonicNow()
+): number => {
+  if (finishedAt < startedAt) {
+    return 0;
+  }
+  return Number(finishedAt - startedAt) / 1_000_000;
+};
+
+export const estimateTimeSaved = (
+  artifactReadyDurationMs: number | undefined,
+  lookupDurationMs: number
+): number | undefined => {
+  if (
+    artifactReadyDurationMs === undefined ||
+    !Number.isFinite(artifactReadyDurationMs) ||
+    artifactReadyDurationMs < 0 ||
+    !Number.isFinite(lookupDurationMs) ||
+    lookupDurationMs < 0
+  ) {
+    return undefined;
+  }
+  return Math.max(0, artifactReadyDurationMs - lookupDurationMs);
+};

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -6,6 +6,7 @@ import * as path from "path";
 import { inventoryCache } from "./cache/catalog";
 import { pruneCache } from "./cache/cleanup";
 import { doctorCache } from "./cache/doctor";
+import { scanResolveEvents, summarizeResolveEvents } from "./cache/events";
 import {
   formatSizeBytes,
   normalizeCacheOptions,
@@ -122,6 +123,20 @@ export const parseCliArguments = (
 const printJson = (value: unknown) =>
   process.stdout.write(`${JSON.stringify(value, null, 2)}\n`);
 
+const formatDuration = (milliseconds: number): string => {
+  const seconds = Math.round(milliseconds / 1000);
+  const hours = Math.floor(seconds / 3600);
+  const minutes = Math.floor((seconds % 3600) / 60);
+  const remainingSeconds = seconds % 60;
+  return [
+    ...(hours > 0 ? [`${hours}h`] : []),
+    ...(minutes > 0 ? [`${minutes}m`] : []),
+    ...(remainingSeconds > 0 || (hours === 0 && minutes === 0)
+      ? [`${remainingSeconds}s`]
+      : []),
+  ].join(" ");
+};
+
 export const runCli = async (arguments_: string[]): Promise<number> => {
   try {
     const parsed = parseCliArguments(arguments_);
@@ -185,6 +200,15 @@ export const runCli = async (arguments_: string[]): Promise<number> => {
         catalog.paths.providerRoot,
         catalog.paths.stateRoot
       );
+      let telemetry;
+      try {
+        const scan = scanResolveEvents(catalog.paths.eventsRoot);
+        telemetry = summarizeResolveEvents(
+          scan.events.map(({ event }) => event)
+        );
+      } catch {
+        telemetry = summarizeResolveEvents([]);
+      }
       const output = {
         entryCount: catalog.entries.length,
         legacyEntryCount: catalog.legacyEntries.length,
@@ -197,8 +221,16 @@ export const runCli = async (arguments_: string[]): Promise<number> => {
         },
         usage: catalog.usage,
         policy,
-        hitRate: null,
-        estimatedTimeSavedMs: null,
+        hitRate: telemetry.hitRate,
+        estimatedTimeSavedMs:
+          telemetry.hits === telemetry.hitsWithoutEstimate
+            ? null
+            : telemetry.estimatedTimeSavedMs,
+        telemetry: {
+          scope: "recorded-retained-resolves",
+          ...telemetry,
+          invalidEventCount: catalog.telemetry.invalidEventCount,
+        },
         issues: catalog.issues,
       };
       if (parsed.json) {
@@ -217,9 +249,19 @@ export const runCli = async (arguments_: string[]): Promise<number> => {
           )}`
         );
         console.log(
-          "Hit rate: unavailable (event telemetry arrives in milestone 3)"
+          output.hitRate === null
+            ? "Hit rate: unavailable (no retained cache decisions)"
+            : `Hit rate: ${(output.hitRate * 100).toFixed(1)}% (${
+                telemetry.hits
+              } hits / ${telemetry.hits + telemetry.misses} decisions)`
         );
-        console.log("Estimated time saved: unavailable");
+        console.log(
+          output.estimatedTimeSavedMs === null
+            ? `Estimated time saved: unavailable (${telemetry.hitsWithoutEstimate} hits lacked timing data)`
+            : `Estimated time saved: ~${formatDuration(
+                output.estimatedTimeSavedMs
+              )} (${telemetry.hitsWithoutEstimate} hits lacked timing data)`
+        );
       }
       return catalog.issues.some((issue) => issue.severity === "error") ? 1 : 0;
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,45 +1,404 @@
-import {
+import * as fs from "fs";
+import * as path from "path";
+
+import type {
   BuildCacheProviderPlugin,
+  CalculateFingerprintHashProps,
   ResolveBuildCacheProps,
   UploadBuildCacheProps,
 } from "@expo/config";
 
-import { resolveCacheEntry, uploadCacheEntry } from "./cache/store";
+import { inventoryCache } from "./cache/catalog";
 import { pruneCache } from "./cache/cleanup";
+import {
+  recordResolveEvent,
+  type ResolveExplanationCode,
+} from "./cache/events";
+import { ensureProviderRoot } from "./cache/filesystem";
+import { calculateProjectFingerprint } from "./cache/fingerprint";
+import {
+  createCacheInsight,
+  normalizeRunProfile,
+  readInsight,
+  runProfilesEqual,
+  selectClosestInsight,
+  type FingerprintSnapshot,
+  type InsightCandidate,
+  type RunProfile,
+} from "./cache/insight";
 import {
   normalizeCacheOptions,
   type CacheProviderOptions,
 } from "./cache/options";
-import { getCachePaths, getEntryId } from "./cache/paths";
+import { getCachePaths, getEntryId, type CachePlatform } from "./cache/paths";
 import { writePolicyState } from "./cache/policy-state";
+import {
+  elapsedMilliseconds,
+  estimateArtifactReadyDuration,
+  estimateTimeSaved,
+  monotonicNow,
+} from "./cache/timing";
+import {
+  resolveCacheEntryDetailed,
+  uploadCacheEntry,
+  type CacheMissReason,
+} from "./cache/store";
+
+type CalculationState = {
+  fingerprintHash: string;
+  snapshot: FingerprintSnapshot | null;
+  updatedAtMs: number;
+};
+
+type PendingBuild = {
+  fingerprintHash: string;
+  missStartedAtMs: number;
+  ambiguous: boolean;
+  updatedAtMs: number;
+};
+
+const LIFECYCLE_STATE_TTL_MS = 30 * 60 * 1000;
+const MAX_LIFECYCLE_STATES = 128;
+
+const calculations = new Map<string, CalculationState>();
+const pendingBuilds = new Map<string, PendingBuild>();
+
+const pruneLifecycleMap = <State extends { updatedAtMs: number }>(
+  states: Map<string, State>,
+  nowMs: number
+): void => {
+  for (const [key, state] of states) {
+    if (nowMs - state.updatedAtMs >= LIFECYCLE_STATE_TTL_MS) {
+      states.delete(key);
+    }
+  }
+
+  if (states.size <= MAX_LIFECYCLE_STATES) {
+    return;
+  }
+  const oldest = [...states.entries()].sort(
+    ([leftKey, left], [rightKey, right]) =>
+      left.updatedAtMs - right.updatedAtMs || leftKey.localeCompare(rightKey)
+  );
+  for (const [key] of oldest.slice(0, states.size - MAX_LIFECYCLE_STATES)) {
+    states.delete(key);
+  }
+};
+
+const pruneLifecycleState = (nowMs = Date.now()): void => {
+  pruneLifecycleMap(calculations, nowMs);
+  pruneLifecycleMap(pendingBuilds, nowMs);
+};
+
+const setCalculation = (
+  key: string,
+  state: Omit<CalculationState, "updatedAtMs">,
+  nowMs: number
+): void => {
+  calculations.set(key, { ...state, updatedAtMs: nowMs });
+  pruneLifecycleMap(calculations, nowMs);
+};
+
+const setPendingBuild = (
+  key: string,
+  state: Omit<PendingBuild, "updatedAtMs">,
+  nowMs: number
+): void => {
+  pendingBuilds.set(key, { ...state, updatedAtMs: nowMs });
+  pruneLifecycleMap(pendingBuilds, nowMs);
+};
 
 const shortFingerprint = (fingerprintHash: string): string =>
   fingerprintHash.replace(/[\r\n\t]/g, "").slice(0, 12);
 
+const getStateKey = (
+  projectRoot: string,
+  platform: CachePlatform,
+  profile: RunProfile
+): string => JSON.stringify([path.resolve(projectRoot), platform, profile]);
+
+const getProfileState = (props: {
+  projectRoot: string;
+  platform: CachePlatform;
+  runOptions: unknown;
+}) => {
+  const profile = normalizeRunProfile(props.platform, props.runOptions);
+  return {
+    profile,
+    key: getStateKey(props.projectRoot, props.platform, profile),
+  };
+};
+
+const explanationForDirectReason = (
+  reason: CacheMissReason
+): { code: ResolveExplanationCode; message: string } => {
+  switch (reason) {
+    case "corrupt":
+      return {
+        code: "corrupt-entry",
+        message: "the previous cache entry failed integrity validation",
+      };
+    case "lock-busy":
+      return {
+        code: "writer-lock-busy",
+        message: "the cache entry is currently owned by another writer",
+      };
+    case "unsafe-legacy-path":
+      return {
+        code: "unsafe-legacy-path",
+        message: "the legacy fingerprint path was unsafe",
+      };
+    case "legacy-invalid":
+      return {
+        code: "legacy-invalid",
+        message: "the legacy artifact was incomplete or invalid",
+      };
+    default:
+      return { code: "no-entry", message: "no matching local entry exists" };
+  }
+};
+
+const evidenceLabels = {
+  "expo-config": {
+    code: "expo-config-changed",
+    label: "Expo config or config plugins changed",
+  },
+  "native-dependencies": {
+    code: "native-dependencies-changed",
+    label: "native dependencies or autolinking changed",
+  },
+  "native-project": {
+    code: "native-project-changed",
+    label: "native project inputs changed",
+  },
+  "project-metadata": {
+    code: "project-metadata-changed",
+    label: "project metadata or patches changed",
+  },
+  other: {
+    code: "other-inputs-changed",
+    label: "other native fingerprint inputs changed",
+  },
+} as const;
+
+const findInsightExplanation = (
+  projectRoot: string,
+  current: FingerprintSnapshot
+): { code: ResolveExplanationCode; messages: string[] } => {
+  try {
+    const catalog = inventoryCache(projectRoot);
+    const candidates: InsightCandidate[] = [];
+    for (const entry of catalog.entries) {
+      if (entry.platform !== current.platform) {
+        continue;
+      }
+      try {
+        const insight = readInsight(entry.directory);
+        if (
+          insight &&
+          insight.entryId === entry.entryId &&
+          insight.fingerprintHash === entry.fingerprintHash &&
+          insight.platform === entry.platform
+        ) {
+          candidates.push({
+            insight,
+            entryId: entry.entryId,
+            createdAt: entry.createdAt,
+            lastAccessAt: entry.lastAccessedAt,
+          });
+        }
+      } catch {
+        // Doctor reports malformed optional metadata; resolution remains usable.
+      }
+    }
+
+    const closest = selectClosestInsight(current, candidates);
+    if (closest.status === "fingerprint-engine-mismatch") {
+      return {
+        code: "fingerprint-engine-mismatch",
+        messages: ["the Expo fingerprint engine version changed"],
+      };
+    }
+    if (closest.status !== "match" || closest.diff.total === 0) {
+      return {
+        code: "no-compatible-insight",
+        messages: ["no compatible prior fingerprint evidence is available"],
+      };
+    }
+
+    const groups = closest.diff.groups.slice(0, 3);
+    const first = groups[0];
+    return {
+      code: first
+        ? evidenceLabels[first.category].code
+        : "no-compatible-insight",
+      messages: groups.map(
+        ({ category, count }) =>
+          `${evidenceLabels[category].label} (${count} source${
+            count === 1 ? "" : "s"
+          })`
+      ),
+    };
+  } catch {
+    return {
+      code: "no-compatible-insight",
+      messages: ["no compatible prior fingerprint evidence is available"],
+    };
+  }
+};
+
+const recordEvent = async (
+  props: ResolveBuildCacheProps,
+  input: {
+    outcome: "hit" | "miss" | "error";
+    lookupDurationMs: number;
+    explanationCode: ResolveExplanationCode;
+    estimatedTimeSavedMs?: number;
+  }
+): Promise<void> => {
+  try {
+    const projectRoot = fs.realpathSync(props.projectRoot);
+    const paths = getCachePaths(projectRoot);
+    ensureProviderRoot(projectRoot, paths.providerRoot);
+    const result = await recordResolveEvent(
+      paths.providerRoot,
+      paths.eventsRoot,
+      {
+        platform: props.platform,
+        entryId: getEntryId(props.platform, props.fingerprintHash),
+        ...input,
+      }
+    );
+    if (result.status === "failed") {
+      console.warn("Could not record cache telemetry", result.error.message);
+    }
+  } catch (error) {
+    console.warn(
+      "Could not record cache telemetry",
+      error instanceof Error ? error.message : error
+    );
+  }
+};
+
 const plugin: BuildCacheProviderPlugin<CacheProviderOptions> = {
+  calculateFingerprintHash: async (
+    props: CalculateFingerprintHashProps,
+    _options: CacheProviderOptions
+  ) => {
+    const { key } = getProfileState(props);
+    pruneLifecycleState();
+    try {
+      const calculation = await calculateProjectFingerprint(props);
+      setCalculation(key, calculation, Date.now());
+      return calculation.fingerprintHash;
+    } catch (error) {
+      calculations.delete(key);
+      pendingBuilds.delete(key);
+      console.warn(
+        "Could not calculate the local build-cache fingerprint; caching is disabled for this build",
+        error instanceof Error ? error.message : error
+      );
+      return null;
+    }
+  },
+
   resolveBuildCache: async (
     props: ResolveBuildCacheProps,
     _options: CacheProviderOptions
   ) => {
     const { fingerprintHash, platform, projectRoot } = props;
     const fingerprint = shortFingerprint(fingerprintHash);
+    const { key, profile } = getProfileState(props);
+    const nowMs = Date.now();
+    pruneLifecycleState(nowMs);
+    const calculation = calculations.get(key);
+    const currentSnapshot =
+      calculation?.fingerprintHash === fingerprintHash
+        ? calculation.snapshot
+        : null;
+    const startedAt = monotonicNow();
     console.log(`Searching for ${platform} cache entry ${fingerprint}`);
 
     try {
-      const cachePath = await resolveCacheEntry({
+      const result = await resolveCacheEntryDetailed({
         projectRoot,
         platform,
         fingerprintHash,
       });
+      const lookupDurationMs = elapsedMilliseconds(startedAt);
 
-      if (cachePath) {
+      if (result.outcome === "hit") {
+        let estimatedTimeSavedMs: number | undefined;
+        if (result.source === "versioned") {
+          try {
+            const insight = readInsight(path.dirname(result.path));
+            if (
+              insight &&
+              insight.entryId === getEntryId(platform, fingerprintHash) &&
+              insight.fingerprintHash === fingerprintHash &&
+              insight.platform === platform &&
+              runProfilesEqual(platform, insight.runProfile, profile)
+            ) {
+              estimatedTimeSavedMs = estimateTimeSaved(
+                insight.artifactReadyEstimate?.durationMs,
+                lookupDurationMs
+              );
+            }
+          } catch (error) {
+            console.warn(
+              "Ignored invalid cache insight",
+              error instanceof Error ? error.message : error
+            );
+          }
+        }
+        await recordEvent(props, {
+          outcome: "hit",
+          lookupDurationMs,
+          explanationCode: "hit",
+          ...(estimatedTimeSavedMs === undefined
+            ? {}
+            : { estimatedTimeSavedMs }),
+        });
+        calculations.delete(key);
+        pendingBuilds.delete(key);
         console.log(`Cache hit for ${platform} fingerprint ${fingerprint}`);
-        return cachePath;
+        return result.path;
       }
 
+      const direct = explanationForDirectReason(result.reason);
+      const explanation =
+        result.reason === "not-found" && currentSnapshot
+          ? findInsightExplanation(projectRoot, currentSnapshot)
+          : { code: direct.code, messages: [direct.message] };
+      const pending = pendingBuilds.get(key);
+      setPendingBuild(
+        key,
+        {
+          fingerprintHash,
+          missStartedAtMs: pending?.missStartedAtMs ?? nowMs,
+          ambiguous: Boolean(pending),
+        },
+        nowMs
+      );
+      await recordEvent(props, {
+        outcome: "miss",
+        lookupDurationMs,
+        explanationCode: explanation.code,
+      });
       console.log(`Cache miss for ${platform} fingerprint ${fingerprint}`);
+      for (const message of explanation.messages) {
+        console.log(`Possible cause: ${message}`);
+      }
       return null;
     } catch (error) {
+      const lookupDurationMs = elapsedMilliseconds(startedAt);
+      calculations.delete(key);
+      pendingBuilds.delete(key);
+      await recordEvent(props, {
+        outcome: "error",
+        lookupDurationMs,
+        explanationCode: "provider-error",
+      });
       console.warn(
         "Cache lookup failed; continuing with a native build",
         error
@@ -54,6 +413,8 @@ const plugin: BuildCacheProviderPlugin<CacheProviderOptions> = {
   ) => {
     const { fingerprintHash, platform, buildPath, projectRoot } = props;
     const fingerprint = shortFingerprint(fingerprintHash);
+    const { key } = getProfileState(props);
+    pruneLifecycleState();
     console.log(`Caching ${platform} build for fingerprint ${fingerprint}`);
 
     try {
@@ -62,9 +423,39 @@ const plugin: BuildCacheProviderPlugin<CacheProviderOptions> = {
         return null;
       }
 
+      const entryId = getEntryId(platform, fingerprintHash);
+      const calculation = calculations.get(key);
+      const pending = pendingBuilds.get(key);
+      let insight;
+      if (
+        calculation?.snapshot &&
+        calculation.fingerprintHash === fingerprintHash
+      ) {
+        const estimate =
+          pending &&
+          !pending.ambiguous &&
+          pending.fingerprintHash === fingerprintHash
+            ? estimateArtifactReadyDuration({
+                artifactPath: buildPath,
+                platform,
+                missStartedAtMs: pending.missStartedAtMs,
+                uploadObservedAtMs: Date.now(),
+              }) ?? undefined
+            : undefined;
+        try {
+          insight = createCacheInsight(calculation.snapshot, entryId, estimate);
+        } catch (error) {
+          console.warn(
+            "Could not prepare cache insight",
+            error instanceof Error ? error.message : error
+          );
+        }
+      }
+
       const cachePath = await uploadCacheEntry(
         { projectRoot, platform, fingerprintHash },
-        buildPath
+        buildPath,
+        insight ? { insight } : {}
       );
       console.log(`Cached ${platform} build at ${cachePath}`);
 
@@ -75,7 +466,7 @@ const plugin: BuildCacheProviderPlugin<CacheProviderOptions> = {
           writePolicyState(paths.providerRoot, paths.stateRoot, policy);
           if (policy.autoPrune) {
             const result = await pruneCache(projectRoot, policy, {
-              protectedEntryIds: [getEntryId(platform, fingerprintHash)],
+              protectedEntryIds: [entryId],
             });
             if (result.removed.length > 0) {
               console.log(
@@ -101,6 +492,9 @@ const plugin: BuildCacheProviderPlugin<CacheProviderOptions> = {
         error
       );
       return null;
+    } finally {
+      calculations.delete(key);
+      pendingBuilds.delete(key);
     }
   },
 };

--- a/test/cache-inspector.test.ts
+++ b/test/cache-inspector.test.ts
@@ -7,6 +7,7 @@ import { removeAccessRecord, touchAccessRecord } from "../src/cache/access";
 import { inventoryCache } from "../src/cache/catalog";
 import { planPrune, pruneCache } from "../src/cache/cleanup";
 import { doctorCache } from "../src/cache/doctor";
+import { recordResolveEvent, scanResolveEvents } from "../src/cache/events";
 import { acquireEntryLock, releaseEntryLock } from "../src/cache/lock";
 import type { NormalizedCachePolicy } from "../src/cache/options";
 import { getCachePaths, getEntryId } from "../src/cache/paths";
@@ -263,6 +264,45 @@ describe("cache catalog and cleanup", () => {
     expect(inventoryCache(projectRoot).entries).toHaveLength(1);
   });
 
+  it("prunes telemetry separately from artifact capacity", async () => {
+    const entry = await seedEntry(
+      "telemetry-entry",
+      "artifact",
+      "2026-08-12T00:00:00.000Z"
+    );
+    const recorded = await recordResolveEvent(
+      entry.paths.providerRoot,
+      entry.paths.eventsRoot,
+      {
+        platform: "android",
+        entryId: entry.entryId,
+        outcome: "miss",
+        lookupDurationMs: 12,
+        explanationCode: "no-entry",
+      },
+      { nowMs: Date.parse("2026-01-01T00:00:00.000Z") }
+    );
+    expect(recorded.status).toBe("recorded");
+
+    const dryRun = await pruneCache(projectRoot, unlimitedPolicy, {
+      dryRun: true,
+      now: new Date("2026-08-13T00:00:00.000Z"),
+    });
+    expect(dryRun.telemetryCandidates).toHaveLength(1);
+    expect(dryRun.reclaimedBytes).toBe(0);
+    expect(dryRun.telemetryReclaimedBytes).toBe(0);
+    expect(fs.existsSync(entry.artifact)).toBe(true);
+
+    const result = await pruneCache(projectRoot, unlimitedPolicy, {
+      now: new Date("2026-08-13T00:00:00.000Z"),
+    });
+    expect(result.telemetryRemoved).toHaveLength(1);
+    expect(result.telemetryReclaimedBytes).toBeGreaterThan(0);
+    expect(result.reclaimedBytes).toBe(0);
+    expect(scanResolveEvents(entry.paths.eventsRoot).events).toEqual([]);
+    expect(fs.existsSync(entry.artifact)).toBe(true);
+  });
+
   it("does not evict an entry with an active lock", async () => {
     const seeded = await seedEntry(
       "locked",
@@ -430,6 +470,26 @@ describe("doctor and CLI", () => {
     );
   });
 
+  it("reports malformed optional insight without invalidating the artifact", async () => {
+    const entry = await seedEntry(
+      "doctor-insight",
+      "healthy",
+      "2026-08-12T00:00:00.000Z"
+    );
+    fs.writeFileSync(
+      path.join(path.dirname(entry.artifact), "insight.json"),
+      "{"
+    );
+
+    const report = doctorCache(projectRoot);
+
+    expect(report.healthy).toBe(false);
+    expect(report.issues).toContainEqual(
+      expect.objectContaining({ code: "invalid-cache-insight" })
+    );
+    expect(fs.existsSync(entry.artifact)).toBe(true);
+  });
+
   it("emits machine-readable stats and list output", async () => {
     await seedEntry("cli", "cli", "2026-08-12T00:00:00.000Z");
 
@@ -460,6 +520,66 @@ describe("doctor and CLI", () => {
         expect(parsed.legacyEntries).toEqual([]);
       }
     }
+  });
+
+  it("reports retained hit rate and conservative time saved", async () => {
+    const entry = await seedEntry(
+      "stats-events",
+      "cli",
+      "2026-08-12T00:00:00.000Z"
+    );
+    for (const event of [
+      {
+        outcome: "miss" as const,
+        lookupDurationMs: 20,
+        explanationCode: "no-entry" as const,
+      },
+      {
+        outcome: "hit" as const,
+        lookupDurationMs: 5,
+        explanationCode: "hit" as const,
+        estimatedTimeSavedMs: 1_000,
+      },
+    ]) {
+      expect(
+        (
+          await recordResolveEvent(
+            entry.paths.providerRoot,
+            entry.paths.eventsRoot,
+            { platform: "android", entryId: entry.entryId, ...event }
+          )
+        ).status
+      ).toBe("recorded");
+    }
+
+    let output = "";
+    const write = spyOn(process.stdout, "write").mockImplementation(((
+      chunk: string | Uint8Array
+    ) => {
+      output += chunk.toString();
+      return true;
+    }) as typeof process.stdout.write);
+    const status = await runCli([
+      "stats",
+      "--project-root",
+      projectRoot,
+      "--json",
+    ]);
+    write.mockRestore();
+
+    expect(status).toBe(0);
+    const parsed = JSON.parse(output) as {
+      hitRate: number;
+      estimatedTimeSavedMs: number;
+      telemetry: { eventCount: number; hits: number; misses: number };
+      usage: { eventsBytes: number };
+    };
+    expect(parsed.hitRate).toBe(0.5);
+    expect(parsed.estimatedTimeSavedMs).toBe(1_000);
+    expect(parsed.telemetry).toEqual(
+      expect.objectContaining({ eventCount: 2, hits: 1, misses: 1 })
+    );
+    expect(parsed.usage.eventsBytes).toBeGreaterThan(0);
   });
 
   it("rejects prune-only policy options on read-only commands", async () => {

--- a/test/events.test.ts
+++ b/test/events.test.ts
@@ -1,0 +1,410 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import * as fs from "fs";
+import * as os from "os";
+import * as path from "path";
+
+import {
+  RESOLVE_EVENT_MAX_BYTES,
+  RESOLVE_EVENT_MAX_COUNT,
+  RESOLVE_EVENT_MAX_LOOKUP_DURATION_MS,
+  RESOLVE_EVENT_MAX_TIME_SAVED_MS,
+  pruneResolveEvents,
+  recordResolveEvent,
+  scanResolveEvents,
+  summarizeResolveEvents,
+  type ResolveEvent,
+  type ResolveEventInput,
+} from "../src/cache/events";
+
+const root = fs.realpathSync(
+  fs.mkdtempSync(path.join(os.tmpdir(), "eas-local-cache-events-"))
+);
+const providerRoot = path.join(root, "v1");
+const eventsRoot = path.join(providerRoot, "events");
+const entryId = "a".repeat(64);
+const defaultInput: ResolveEventInput = {
+  platform: "ios",
+  entryId,
+  outcome: "miss",
+  lookupDurationMs: 12.5,
+  explanationCode: "no-entry",
+};
+
+const resetRoot = (): void => {
+  fs.rmSync(root, { recursive: true, force: true });
+  fs.mkdirSync(providerRoot, { recursive: true });
+};
+
+afterEach(resetRoot, 120_000);
+resetRoot();
+
+const timestampToken = (timestamp: string): string =>
+  timestamp.replaceAll("-", "").replaceAll(":", "").replace(".", "");
+
+const uuidFor = (index: number): string => {
+  const value = index.toString(16).padStart(30, "0").slice(-30);
+  return `${value.slice(0, 8)}-${value.slice(8, 12)}-4${value.slice(
+    12,
+    15
+  )}-8${value.slice(15, 18)}-${value.slice(18, 30)}`;
+};
+
+const writeRawEvent = (
+  event: ResolveEvent,
+  index: number,
+  overrides: { day?: string; contents?: string } = {}
+): string => {
+  const day = overrides.day ?? event.timestamp.slice(0, 10);
+  const directory = path.join(eventsRoot, day);
+  fs.mkdirSync(directory, { recursive: true });
+  const filePath = path.join(
+    directory,
+    `${timestampToken(event.timestamp)}-${uuidFor(index)}.json`
+  );
+  fs.writeFileSync(
+    filePath,
+    overrides.contents ?? `${JSON.stringify(event)}\n`,
+    { mode: 0o600 }
+  );
+  return filePath;
+};
+
+const eventAt = (
+  timestamp: string,
+  overrides: Partial<ResolveEvent> = {}
+): ResolveEvent => ({
+  schemaVersion: 1,
+  timestamp,
+  platform: "ios",
+  entryId,
+  outcome: "miss",
+  lookupDurationMs: 1,
+  explanationCode: "no-entry",
+  ...overrides,
+});
+
+describe("resolve event telemetry", () => {
+  it("publishes a private immutable event in its UTC bucket", async () => {
+    const nowMs = Date.parse("2026-08-13T04:05:06.789Z");
+    const result = await recordResolveEvent(
+      providerRoot,
+      eventsRoot,
+      defaultInput,
+      {
+        nowMs,
+        randomUUID: () => "12345678-1234-4123-8123-123456789abc",
+      }
+    );
+
+    expect(result.status).toBe("recorded");
+    if (result.status !== "recorded") {
+      throw new Error("Expected telemetry event to be recorded");
+    }
+    expect(path.relative(eventsRoot, result.filePath)).toBe(
+      path.join(
+        "2026-08-13",
+        "20260813T040506789Z-12345678-1234-4123-8123-123456789abc.json"
+      )
+    );
+    expect(fs.statSync(result.filePath).mode & 0o777).toBe(0o600);
+    expect(
+      fs
+        .readdirSync(path.dirname(result.filePath))
+        .some((name) => name.startsWith(".tmp-"))
+    ).toBe(false);
+
+    const scan = scanResolveEvents(eventsRoot);
+    expect(scan.invalid).toEqual([]);
+    expect(scan.events.map(({ event }) => event)).toEqual([
+      {
+        schemaVersion: 1,
+        timestamp: "2026-08-13T04:05:06.789Z",
+        ...defaultInput,
+      },
+    ]);
+    expect(scan.validBytes).toBeGreaterThan(0);
+    expect(scan.totalBytes).toBe(scan.validBytes);
+  });
+
+  it("rejects symlinked, oversized, malformed, and mismatched UTC records", () => {
+    const timestamp = "2026-08-13T00:00:00.000Z";
+    const valid = eventAt(timestamp);
+    writeRawEvent(valid, 1);
+    writeRawEvent(valid, 2, { contents: "not-json" });
+    writeRawEvent(valid, 3, {
+      contents: "x".repeat(RESOLVE_EVENT_MAX_BYTES + 1),
+    });
+    writeRawEvent(valid, 4, { day: "2026-08-12" });
+
+    const symlinkPath = writeRawEvent(valid, 5);
+    fs.unlinkSync(symlinkPath);
+    fs.symlinkSync(
+      path.join(
+        eventsRoot,
+        "2026-08-13",
+        path.basename(writeRawEvent(valid, 6))
+      ),
+      symlinkPath
+    );
+
+    const scan = scanResolveEvents(eventsRoot);
+    expect(scan.events).toHaveLength(2);
+    expect(scan.invalid).toHaveLength(4);
+    expect(scan.invalid.map(({ reason }) => reason).join("\n")).toContain(
+      "size limit"
+    );
+    expect(scan.invalid.map(({ reason }) => reason).join("\n")).toContain(
+      "regular file"
+    );
+    expect(scan.invalid.map(({ reason }) => reason).join("\n")).toContain(
+      "UTC path"
+    );
+  });
+
+  it("rejects huge finite metrics before they can corrupt aggregates", () => {
+    const timestamp = "2026-08-13T00:00:00.000Z";
+    writeRawEvent(
+      eventAt(timestamp, { lookupDurationMs: Number.MAX_VALUE }),
+      1
+    );
+    writeRawEvent(
+      eventAt(timestamp, {
+        outcome: "hit",
+        explanationCode: "hit",
+        lookupDurationMs: 1,
+        estimatedTimeSavedMs: Number.MAX_VALUE,
+      }),
+      2
+    );
+
+    const scan = scanResolveEvents(eventsRoot);
+    expect(scan.events).toEqual([]);
+    expect(scan.invalid).toHaveLength(2);
+    expect(() =>
+      summarizeResolveEvents([
+        eventAt(timestamp, {
+          lookupDurationMs: RESOLVE_EVENT_MAX_LOOKUP_DURATION_MS + 1,
+        }),
+      ])
+    ).toThrow("malformed fields");
+    expect(() =>
+      summarizeResolveEvents([
+        eventAt(timestamp, {
+          outcome: "hit",
+          explanationCode: "hit",
+          estimatedTimeSavedMs: RESOLVE_EVENT_MAX_TIME_SAVED_MS + 1,
+        }),
+      ])
+    ).toThrow("malformed fields");
+    expect(() =>
+      summarizeResolveEvents(
+        Array.from({ length: RESOLVE_EVENT_MAX_COUNT + 1 }, () =>
+          eventAt(timestamp)
+        )
+      )
+    ).toThrow("retained event limit");
+  });
+
+  it("skips quickly when the dedicated telemetry lock is busy", async () => {
+    fs.mkdirSync(path.join(eventsRoot, ".telemetry.lock"), {
+      recursive: true,
+    });
+    fs.writeFileSync(
+      path.join(eventsRoot, ".telemetry.lock", "owner.json"),
+      `${JSON.stringify({
+        token: "active",
+        pid: process.pid,
+        hostname: os.hostname(),
+        createdAt: new Date().toISOString(),
+      })}\n`
+    );
+
+    const result = await recordResolveEvent(
+      providerRoot,
+      eventsRoot,
+      defaultInput,
+      { maxLockWaitMs: 0 }
+    );
+
+    expect(result).toEqual({ status: "lock-busy" });
+    expect(scanResolveEvents(eventsRoot).events).toEqual([]);
+  });
+
+  it("does not lose events from concurrent provider processes", async () => {
+    const writer = path.join(
+      import.meta.dir,
+      "fixtures",
+      "telemetry-writer.ts"
+    );
+    const processes = Array.from({ length: 12 }, () =>
+      Bun.spawn([process.execPath, writer, providerRoot, eventsRoot, entryId], {
+        stdout: "pipe",
+        stderr: "pipe",
+      })
+    );
+    const exitCodes = await Promise.all(processes.map((child) => child.exited));
+
+    if (exitCodes.some((code) => code !== 0)) {
+      const errors = await Promise.all(
+        processes.map((child) => new Response(child.stderr).text())
+      );
+      throw new Error(errors.filter(Boolean).join("\n"));
+    }
+    expect(scanResolveEvents(eventsRoot).events).toHaveLength(12);
+  });
+
+  it("strictly retains 90 days and at most 10,000 events after every write", async () => {
+    const nowMs = Date.parse("2026-08-13T12:00:00.000Z");
+    const recentTimestamp = "2026-08-13T11:00:00.000Z";
+    const expiredTimestamp = "2026-05-15T11:59:59.999Z";
+    writeRawEvent(eventAt(expiredTimestamp), RESOLVE_EVENT_MAX_COUNT + 1);
+    for (let index = 0; index < RESOLVE_EVENT_MAX_COUNT; index += 1) {
+      writeRawEvent(eventAt(recentTimestamp), index);
+    }
+
+    const result = await recordResolveEvent(
+      providerRoot,
+      eventsRoot,
+      defaultInput,
+      { nowMs }
+    );
+
+    expect(result.status).toBe("recorded");
+    const scan = scanResolveEvents(eventsRoot);
+    expect(scan.events).toHaveLength(RESOLVE_EVENT_MAX_COUNT);
+    expect(
+      scan.events.some(({ event }) => event.timestamp === expiredTimestamp)
+    ).toBe(false);
+    expect(scan.events.at(-1)?.event.timestamp).toBe(
+      "2026-08-13T12:00:00.000Z"
+    );
+  }, 120_000);
+
+  it("removes invalid owned records so malformed files cannot evade the cap", async () => {
+    const malformedPath = writeRawEvent(
+      eventAt("2026-08-13T11:00:00.000Z"),
+      1,
+      { contents: "not-json" }
+    );
+    const symlinkPath = writeRawEvent(eventAt("2026-08-13T11:00:01.000Z"), 2);
+    fs.unlinkSync(symlinkPath);
+    fs.symlinkSync(malformedPath, symlinkPath);
+    const temporaryPath = path.join(
+      eventsRoot,
+      "2026-08-13",
+      ".tmp-123-12345678-1234-4123-8123-123456789abc"
+    );
+    fs.writeFileSync(temporaryPath, "partial");
+
+    const result = await recordResolveEvent(
+      providerRoot,
+      eventsRoot,
+      defaultInput,
+      { nowMs: Date.parse("2026-08-13T12:00:00.000Z") }
+    );
+
+    expect(result.status).toBe("recorded");
+    expect(fs.existsSync(malformedPath)).toBe(false);
+    expect(fs.existsSync(symlinkPath)).toBe(false);
+    expect(fs.existsSync(temporaryPath)).toBe(false);
+    const scan = scanResolveEvents(eventsRoot);
+    expect(scan.invalid).toEqual([]);
+    expect(scan.events).toHaveLength(1);
+  });
+
+  it("uses the dedicated lock for dry-run and manual retention cleanup", async () => {
+    const nowMs = Date.parse("2026-08-13T12:00:00.000Z");
+    const expiredTimestamp = "2026-05-15T11:59:59.999Z";
+    const expiredPath = writeRawEvent(eventAt(expiredTimestamp), 1);
+    const invalidPath = writeRawEvent(eventAt("2026-08-13T11:00:00.000Z"), 2, {
+      contents: "invalid",
+    });
+
+    const dryRun = await pruneResolveEvents(providerRoot, eventsRoot, {
+      nowMs,
+      dryRun: true,
+    });
+    expect(dryRun).toEqual({
+      status: "pruned",
+      candidates: [
+        {
+          filePath: invalidPath,
+          timestamp: null,
+          sizeBytes: fs.statSync(invalidPath).size,
+          reason: "invalid",
+        },
+        {
+          filePath: expiredPath,
+          timestamp: expiredTimestamp,
+          sizeBytes: fs.statSync(expiredPath).size,
+          reason: "expired",
+        },
+      ],
+      removed: [],
+      removedCount: 0,
+      removedBytes: 0,
+    });
+    expect(fs.existsSync(expiredPath)).toBe(true);
+    expect(fs.existsSync(invalidPath)).toBe(true);
+
+    const applied = await pruneResolveEvents(providerRoot, eventsRoot, {
+      nowMs,
+    });
+    expect(applied.status).toBe("pruned");
+    if (applied.status === "pruned") {
+      expect(applied.removedCount).toBe(2);
+      expect(applied.removedBytes).toBeGreaterThan(0);
+    }
+    expect(fs.existsSync(expiredPath)).toBe(false);
+    expect(fs.existsSync(invalidPath)).toBe(false);
+  });
+
+  it("returns an empty scan before the telemetry directory exists", () => {
+    expect(scanResolveEvents(eventsRoot)).toEqual({
+      events: [],
+      invalid: [],
+      validBytes: 0,
+      invalidBytes: 0,
+      totalBytes: 0,
+    });
+  });
+
+  it("summarizes retained decisions, lookup time, and conservative savings", () => {
+    const events = [
+      eventAt("2026-08-13T00:00:03.000Z", {
+        outcome: "hit",
+        explanationCode: "hit",
+        lookupDurationMs: 3,
+        estimatedTimeSavedMs: 100,
+      }),
+      eventAt("2026-08-13T00:00:01.000Z", {
+        outcome: "hit",
+        explanationCode: "hit",
+        lookupDurationMs: 2,
+      }),
+      eventAt("2026-08-13T00:00:02.000Z", {
+        outcome: "miss",
+        lookupDurationMs: 4,
+      }),
+      eventAt("2026-08-13T00:00:04.000Z", {
+        outcome: "error",
+        explanationCode: "provider-error",
+        lookupDurationMs: 5,
+      }),
+    ];
+
+    expect(summarizeResolveEvents(events)).toEqual({
+      eventCount: 4,
+      hits: 2,
+      misses: 1,
+      errors: 1,
+      hitRate: 2 / 3,
+      lookupDurationMs: 14,
+      estimatedTimeSavedMs: 100,
+      hitsWithoutEstimate: 1,
+      windowStart: "2026-08-13T00:00:01.000Z",
+      windowEnd: "2026-08-13T00:00:04.000Z",
+    });
+    expect(summarizeResolveEvents([]).hitRate).toBeNull();
+  });
+});

--- a/test/fingerprint.test.ts
+++ b/test/fingerprint.test.ts
@@ -1,0 +1,193 @@
+import { afterAll, describe, expect, it } from "bun:test";
+import * as fs from "fs";
+import * as os from "os";
+import * as path from "path";
+
+import {
+  calculateProjectFingerprint,
+  loadProjectFingerprintEngine,
+} from "../src/cache/fingerprint";
+import { MAX_INSIGHT_SOURCES, normalizeRunProfile } from "../src/cache/insight";
+
+const roots: string[] = [];
+
+afterAll(() => {
+  for (const root of roots) {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+const makeProject = (moduleSource: string, version = "9.8.7") => {
+  const projectRoot = fs.realpathSync(
+    fs.mkdtempSync(path.join(os.tmpdir(), "eas-local-fingerprint-"))
+  );
+  roots.push(projectRoot);
+  const packageRoot = path.join(
+    projectRoot,
+    "node_modules",
+    "@expo",
+    "fingerprint"
+  );
+  fs.mkdirSync(packageRoot, { recursive: true });
+  fs.writeFileSync(
+    path.join(projectRoot, "package.json"),
+    JSON.stringify({ name: "fixture", private: true })
+  );
+  fs.writeFileSync(
+    path.join(packageRoot, "package.json"),
+    JSON.stringify({
+      name: "@expo/fingerprint",
+      version,
+      main: "index.js",
+    })
+  );
+  fs.writeFileSync(path.join(packageRoot, "index.js"), moduleSource);
+  return projectRoot;
+};
+
+describe("requested run profiles", () => {
+  it("keeps only normalized iOS diagnostic fields", () => {
+    expect(
+      normalizeRunProfile("ios", {
+        configuration: "Release",
+        scheme: "Example",
+        device: "SECRET-DEVICE-ID",
+        port: 8081,
+        appId: "com.secret.app",
+      })
+    ).toEqual({ configuration: "Release", scheme: "Example" });
+    expect(normalizeRunProfile("ios", { scheme: true })).toEqual({
+      configuration: "Debug",
+      scheme: "default",
+    });
+  });
+
+  it("keeps only normalized Android diagnostic fields", () => {
+    expect(
+      normalizeRunProfile("android", {
+        variant: "release",
+        allArch: true,
+        device: "SECRET-DEVICE-ID",
+        binary: "/secret/app.apk",
+      })
+    ).toEqual({ variant: "release", allArch: true });
+    expect(normalizeRunProfile("android", { allArch: "yes" })).toEqual({
+      variant: "debug",
+      allArch: false,
+    });
+  });
+});
+
+describe("project-local Expo fingerprint loading", () => {
+  it("returns Expo's exact hash and calls the project engine with parity options", async () => {
+    const projectRoot = makeProject(`
+      const fs = require("fs");
+      const path = require("path");
+      exports.createFingerprintAsync = async (root, options) => {
+        fs.writeFileSync(path.join(root, "fingerprint-call.json"), JSON.stringify({ root, options }));
+        return {
+          hash: "expo-hash-exactly-as-returned",
+          sources: [
+            {
+              type: "contents",
+              id: "PRIVATE-CONTENTS-ID",
+              contents: "TOKEN=do-not-persist",
+              reasons: ["unknown:PRIVATE-REASON"],
+              hash: "AA11"
+            },
+            {
+              type: "file",
+              filePath: "ios/Podfile",
+              reasons: ["bareNativeDir"],
+              hash: "BB22",
+              debugInfo: { path: "/private/debug/path" }
+            }
+          ]
+        };
+      };
+    `);
+    fs.mkdirSync(path.join(projectRoot, "ios"));
+    fs.writeFileSync(path.join(projectRoot, "ios", "Podfile"), "platform :ios");
+
+    const engine = loadProjectFingerprintEngine(projectRoot);
+    expect(engine.version).toBe("9.8.7");
+    expect(engine.modulePath.startsWith(projectRoot)).toBe(true);
+
+    const result = await calculateProjectFingerprint({
+      projectRoot,
+      platform: "ios",
+      runOptions: { configuration: "Release", device: "SECRET-DEVICE" },
+      now: () => new Date("2026-08-13T01:02:03.000Z"),
+    });
+
+    expect(result.fingerprintHash).toBe("expo-hash-exactly-as-returned");
+    expect(
+      JSON.parse(
+        fs.readFileSync(path.join(projectRoot, "fingerprint-call.json"), "utf8")
+      )
+    ).toEqual({ root: projectRoot, options: { silent: true } });
+    expect(result.snapshot?.fingerprintEngineVersion).toBe("9.8.7");
+    expect(result.snapshot?.sources[0]?.categories).toEqual(["other"]);
+    expect(result.snapshot?.sources[1]).toMatchObject({
+      displayPath: "ios/Podfile",
+      digest: "bb22",
+      categories: ["native-project"],
+    });
+
+    const serialized = JSON.stringify(result.snapshot);
+    expect(serialized).not.toContain("TOKEN=do-not-persist");
+    expect(serialized).not.toContain("PRIVATE-CONTENTS-ID");
+    expect(serialized).not.toContain("PRIVATE-REASON");
+    expect(serialized).not.toContain("/private/debug/path");
+    expect(serialized).not.toContain(projectRoot);
+    expect(serialized).not.toContain("SECRET-DEVICE");
+  });
+
+  it("keeps hash parity while omitting an over-limit snapshot", async () => {
+    const projectRoot = makeProject(`
+      exports.createFingerprintAsync = async () => ({
+        hash: "still-valid-hash",
+        sources: Array.from({ length: ${
+          MAX_INSIGHT_SOURCES + 1
+        } }, (_, index) => ({
+          type: "contents",
+          id: "source-" + index,
+          contents: "secret-" + index,
+          reasons: ["expoConfig"],
+          hash: "aa"
+        }))
+      });
+    `);
+
+    const result = await calculateProjectFingerprint({
+      projectRoot,
+      platform: "android",
+      runOptions: {},
+    });
+
+    expect(result).toEqual({
+      fingerprintHash: "still-valid-hash",
+      snapshot: null,
+    });
+  });
+
+  it("rejects missing and malformed project-local engines", async () => {
+    const missingRoot = fs.realpathSync(
+      fs.mkdtempSync(path.join(os.tmpdir(), "eas-local-fingerprint-missing-"))
+    );
+    roots.push(missingRoot);
+    fs.writeFileSync(path.join(missingRoot, "package.json"), "{}");
+    expect(() => loadProjectFingerprintEngine(missingRoot)).toThrow();
+
+    const malformedRoot = makeProject(
+      "exports.createFingerprintAsync = async () => ({ hash: null, sources: [] });"
+    );
+    expect(
+      calculateProjectFingerprint({
+        projectRoot: malformedRoot,
+        platform: "ios",
+        runOptions: {},
+      })
+    ).rejects.toThrow("malformed output");
+  });
+});

--- a/test/fixtures/telemetry-writer.ts
+++ b/test/fixtures/telemetry-writer.ts
@@ -1,0 +1,23 @@
+import { recordResolveEvent } from "../../src/cache/events";
+
+const [providerRoot, eventsRoot, entryId] = process.argv.slice(2);
+if (!providerRoot || !eventsRoot || !entryId) {
+  throw new Error("Expected provider root, events root, and entry ID");
+}
+
+const result = await recordResolveEvent(
+  providerRoot,
+  eventsRoot,
+  {
+    platform: "ios",
+    entryId,
+    outcome: "hit",
+    lookupDurationMs: 1,
+    explanationCode: "hit",
+  },
+  { maxLockWaitMs: 2_000 }
+);
+
+if (result.status !== "recorded") {
+  throw new Error(`Telemetry writer failed: ${result.status}`);
+}

--- a/test/insight.test.ts
+++ b/test/insight.test.ts
@@ -1,0 +1,327 @@
+import { afterAll, describe, expect, it } from "bun:test";
+import * as fs from "fs";
+import * as os from "os";
+import * as path from "path";
+
+import {
+  EVIDENCE_CATEGORIES,
+  INSIGHT_FILENAME,
+  MAX_INSIGHT_BYTES,
+  MAX_INSIGHT_SOURCES,
+  createCacheInsight,
+  diffInsights,
+  getTopEvidenceGroups,
+  readInsight,
+  sanitizeFingerprintSources,
+  selectClosestInsight,
+  writeInsightAtomically,
+  type CacheInsight,
+  type FingerprintSnapshot,
+  type InsightCandidate,
+  type InsightSource,
+} from "../src/cache/insight";
+
+const roots: string[] = [];
+
+afterAll(() => {
+  for (const root of roots) {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+const makeRoot = () => {
+  const root = fs.realpathSync(
+    fs.mkdtempSync(path.join(os.tmpdir(), "eas-local-insight-"))
+  );
+  roots.push(root);
+  return root;
+};
+
+const source = (
+  comparatorHash: string,
+  digest: string | null,
+  categories: InsightSource["categories"] = ["other"],
+  occurrence = 0
+): InsightSource => ({
+  type: "contents",
+  comparatorHash: comparatorHash.padEnd(64, "0"),
+  occurrence,
+  digest,
+  categories,
+});
+
+const snapshot = (
+  sources: InsightSource[],
+  overrides: Partial<FingerprintSnapshot> = {}
+): FingerprintSnapshot => ({
+  platform: "ios",
+  fingerprintHash: "fingerprint-hash",
+  capturedAt: "2026-08-13T01:02:03.000Z",
+  fingerprintEngineVersion: "0.20.7",
+  runProfile: { configuration: "Debug", scheme: "default" },
+  sources,
+  ...overrides,
+});
+
+const insight = (
+  sources: InsightSource[],
+  entryId = "a".repeat(64),
+  overrides: Partial<FingerprintSnapshot> = {}
+): CacheInsight => createCacheInsight(snapshot(sources, overrides), entryId);
+
+describe("fingerprint source sanitization", () => {
+  it("hashes identities, keeps duplicate order, and stores only fixed categories", () => {
+    const root = makeRoot();
+    fs.mkdirSync(path.join(root, "ios"));
+    fs.writeFileSync(path.join(root, "ios", "Podfile"), "pod contents");
+
+    const result = sanitizeFingerprintSources(root, [
+      {
+        type: "file",
+        filePath: "ios/Podfile",
+        hash: "ABC123",
+        reasons: ["bareNativeDir", "unknown-secret-reason"],
+      },
+      {
+        type: "file",
+        filePath: "ios/Podfile",
+        hash: null,
+        reasons: ["expoConfig"],
+      },
+      {
+        type: "contents",
+        id: "secret-identity",
+        contents: "secret-contents",
+        hash: "00FF",
+        reasons: ["package:react-native"],
+      },
+    ]);
+
+    expect(result).not.toBeNull();
+    expect(result?.[0]).toMatchObject({
+      occurrence: 0,
+      displayPath: "ios/Podfile",
+      digest: "abc123",
+      categories: ["native-project", "other"],
+    });
+    expect(result?.[1]).toMatchObject({
+      occurrence: 1,
+      digest: null,
+      categories: ["expo-config"],
+    });
+    expect(result?.[0]?.comparatorHash).toBe(result?.[1]?.comparatorHash);
+    expect(result?.[2]?.categories).toEqual(["native-dependencies"]);
+    const serialized = JSON.stringify(result);
+    expect(serialized).not.toContain("secret-identity");
+    expect(serialized).not.toContain("secret-contents");
+    expect(serialized).not.toContain("unknown-secret-reason");
+    expect(EVIDENCE_CATEGORIES).toContain(result?.[2]?.categories[0]!);
+  });
+
+  it("omits unsafe displays and rejects incomplete or oversized snapshots", () => {
+    const root = makeRoot();
+    const outside = path.join(path.dirname(root), "outside-native-file");
+    fs.writeFileSync(outside, "outside");
+    const symlink = path.join(root, "linked-native-file");
+    fs.symlinkSync(outside, symlink);
+
+    const result = sanitizeFingerprintSources(root, [
+      { type: "file", filePath: outside, hash: "aa", reasons: [] },
+      { type: "file", filePath: symlink, hash: "bb", reasons: [] },
+    ]);
+    expect(result?.every((item) => item.displayPath === undefined)).toBe(true);
+    expect(
+      sanitizeFingerprintSources(root, [
+        { type: "contents", hash: "aa", reasons: [] },
+      ])
+    ).toBeNull();
+    expect(
+      sanitizeFingerprintSources(root, [
+        {
+          type: "contents",
+          id: "malformed-digest",
+          hash: "not-a-hex-digest",
+          reasons: [],
+        },
+      ])
+    ).toBeNull();
+    expect(
+      sanitizeFingerprintSources(
+        root,
+        Array.from({ length: MAX_INSIGHT_SOURCES + 1 }, (_, index) => ({
+          type: "contents" as const,
+          id: `id-${index}`,
+          hash: "aa",
+          reasons: [],
+        }))
+      )
+    ).toBeNull();
+    fs.rmSync(outside, { force: true });
+  });
+});
+
+describe("insight persistence", () => {
+  it("atomically round-trips a private regular file", () => {
+    const root = makeRoot();
+    const record = insight([source("1", "aa")]);
+
+    writeInsightAtomically(root, record);
+
+    expect(readInsight(root)).toEqual(record);
+    expect(fs.statSync(path.join(root, INSIGHT_FILENAME)).mode & 0o777).toBe(
+      0o600
+    );
+    expect(
+      fs.readdirSync(root).filter((name) => name.endsWith(".tmp"))
+    ).toEqual([]);
+    expect(() => writeInsightAtomically(root, record)).toThrow(
+      "already exists"
+    );
+  });
+
+  it("returns null when absent and rejects symlinked, oversized, or malformed records", () => {
+    const root = makeRoot();
+    expect(readInsight(root)).toBeNull();
+
+    const target = path.join(root, "target.json");
+    fs.writeFileSync(target, JSON.stringify(insight([])));
+    fs.symlinkSync(target, path.join(root, INSIGHT_FILENAME));
+    expect(() => readInsight(root)).toThrow();
+    fs.unlinkSync(path.join(root, INSIGHT_FILENAME));
+
+    fs.writeFileSync(
+      path.join(root, INSIGHT_FILENAME),
+      Buffer.alloc(MAX_INSIGHT_BYTES + 1)
+    );
+    expect(() => readInsight(root)).toThrow("1 MiB");
+    fs.writeFileSync(path.join(root, INSIGHT_FILENAME), "{}");
+    expect(() => readInsight(root)).toThrow("malformed");
+
+    const traversal = {
+      ...insight([source("1", "aa")]),
+      sources: [
+        {
+          ...source("1", "aa"),
+          displayPath: "ios/../../private/file",
+        },
+      ],
+    };
+    fs.writeFileSync(
+      path.join(root, INSIGHT_FILENAME),
+      JSON.stringify(traversal)
+    );
+    expect(() => readInsight(root)).toThrow("malformed");
+  });
+
+  it("omits an insight rather than serializing a partial over-limit snapshot", () => {
+    const manySources = Array.from(
+      { length: MAX_INSIGHT_SOURCES },
+      (_, index) =>
+        source(index.toString(16).padStart(64, "0"), "a".repeat(256), [
+          "expo-config",
+        ])
+    );
+    expect(() => insight(manySources)).toThrow("1 MiB");
+  });
+});
+
+describe("insight diffing and candidate ranking", () => {
+  it("matches duplicate occurrences and groups changed sources deterministically", () => {
+    const before = insight([
+      source("1", "aa", ["expo-config"]),
+      source("1", "bb", ["native-project"], 1),
+      source("2", "cc", ["other"]),
+      source("3", "dd", ["native-dependencies"]),
+    ]);
+    const after = insight([
+      source("1", "ff", ["expo-config"]),
+      source("1", "bb", ["native-project"], 1),
+      source("3", "dd", ["native-dependencies"]),
+      source("4", "ee", ["native-dependencies"]),
+    ]);
+
+    const diff = diffInsights(before, after);
+    expect({
+      added: diff.added,
+      removed: diff.removed,
+      changed: diff.changed,
+      total: diff.total,
+    }).toEqual({ added: 1, removed: 1, changed: 1, total: 3 });
+    expect(diff.groups).toEqual([
+      { category: "expo-config", count: 1 },
+      { category: "native-dependencies", count: 1 },
+      { category: "other", count: 1 },
+    ]);
+    expect(
+      getTopEvidenceGroups({
+        groups: [...diff.groups, { category: "native-project", count: 1 }],
+      })
+    ).toHaveLength(3);
+  });
+
+  it("selects minimum diff then newest access, creation, and entry ID", () => {
+    const current = snapshot([source("1", "aa")]);
+    const candidates: InsightCandidate[] = [
+      {
+        insight: insight([source("1", "bb")], "b".repeat(64)),
+        entryId: "b".repeat(64),
+        createdAt: "2026-08-10T00:00:00.000Z",
+        lastAccessAt: "2026-08-12T00:00:00.000Z",
+      },
+      {
+        insight: insight([source("1", "bb")], "a".repeat(64)),
+        entryId: "a".repeat(64),
+        createdAt: "2026-08-11T00:00:00.000Z",
+        lastAccessAt: "2026-08-12T00:00:00.000Z",
+      },
+      {
+        insight: insight(
+          [source("1", "bb"), source("2", "cc")],
+          "0".repeat(64)
+        ),
+        entryId: "0".repeat(64),
+        createdAt: "2026-08-13T00:00:00.000Z",
+        lastAccessAt: "2026-08-13T00:00:00.000Z",
+      },
+      {
+        insight: insight([source("1", "bb")], "c".repeat(64)),
+        entryId: "c".repeat(64),
+        createdAt: "2026-08-11T00:00:00.000Z",
+        lastAccessAt: "2026-08-12T00:00:00.000Z",
+      },
+    ];
+
+    const selected = selectClosestInsight(current, candidates);
+    expect(selected.status).toBe("match");
+    if (selected.status === "match") {
+      expect(selected.candidate.entryId).toBe("a".repeat(64));
+      expect(selected.diff.total).toBe(1);
+    }
+  });
+
+  it("does not guess across profile or fingerprint-engine changes", () => {
+    const current = snapshot([]);
+    expect(
+      selectClosestInsight(current, [
+        {
+          insight: insight([], "a".repeat(64), {
+            runProfile: { configuration: "Release", scheme: "default" },
+          }),
+          entryId: "a".repeat(64),
+          createdAt: "2026-08-13T00:00:00.000Z",
+        },
+      ]).status
+    ).toBe("no-compatible-profile");
+    expect(
+      selectClosestInsight(current, [
+        {
+          insight: insight([], "b".repeat(64), {
+            fingerprintEngineVersion: "99.0.0",
+          }),
+          entryId: "b".repeat(64),
+          createdAt: "2026-08-13T00:00:00.000Z",
+        },
+      ]).status
+    ).toBe("fingerprint-engine-mismatch");
+  });
+});

--- a/test/plugin.test.ts
+++ b/test/plugin.test.ts
@@ -1,5 +1,6 @@
-import { afterAll, beforeEach, describe, expect, it } from "bun:test";
+import { afterAll, beforeEach, describe, expect, it, spyOn } from "bun:test";
 import type {
+  CalculateFingerprintHashProps,
   ResolveBuildCacheProps,
   UploadBuildCacheProps,
 } from "@expo/config";
@@ -11,6 +12,8 @@ import plugin from "../src/index";
 import { removeAccessRecord, touchAccessRecord } from "../src/cache/access";
 import { acquireEntryLock, releaseEntryLock } from "../src/cache/lock";
 import { readManifest } from "../src/cache/manifest";
+import { readInsight } from "../src/cache/insight";
+import { scanResolveEvents } from "../src/cache/events";
 import {
   getCachePaths,
   getEntryDirectory,
@@ -22,11 +25,18 @@ const projectRoot = fs.realpathSync(
 );
 const cacheDir = path.join(projectRoot, ".expo", "cache");
 
-if (!("resolveBuildCache" in plugin) || !("uploadBuildCache" in plugin)) {
-  throw new Error("Plugin must implement resolveBuildCache/uploadBuildCache");
+if (
+  typeof plugin.calculateFingerprintHash !== "function" ||
+  !("resolveBuildCache" in plugin) ||
+  !("uploadBuildCache" in plugin)
+) {
+  throw new Error(
+    "Plugin must implement calculateFingerprintHash/resolveBuildCache/uploadBuildCache"
+  );
 }
 
-const { resolveBuildCache, uploadBuildCache } = plugin;
+const { calculateFingerprintHash, resolveBuildCache, uploadBuildCache } =
+  plugin;
 
 afterAll(() => {
   fs.rmSync(projectRoot, { recursive: true, force: true });
@@ -39,22 +49,75 @@ beforeEach(() => {
 const resolveProps = (
   platform: "ios" | "android",
   fingerprintHash: string,
-  root = projectRoot
+  root = projectRoot,
+  runOptions: ResolveBuildCacheProps["runOptions"] = {}
 ): ResolveBuildCacheProps =>
-  ({ projectRoot: root, platform, fingerprintHash } as ResolveBuildCacheProps);
+  ({
+    projectRoot: root,
+    platform,
+    fingerprintHash,
+    runOptions,
+  } as ResolveBuildCacheProps);
 
 const uploadProps = (
   platform: "ios" | "android",
   fingerprintHash: string,
   buildPath: string,
-  root = projectRoot
+  root = projectRoot,
+  runOptions: UploadBuildCacheProps["runOptions"] = {}
 ): UploadBuildCacheProps =>
   ({
     projectRoot: root,
     platform,
     fingerprintHash,
     buildPath,
+    runOptions,
   } as UploadBuildCacheProps);
+
+const calculateProps = (
+  platform: "ios" | "android",
+  root = projectRoot,
+  runOptions: CalculateFingerprintHashProps["runOptions"] = platform === "ios"
+    ? { configuration: "Debug" }
+    : {}
+): CalculateFingerprintHashProps => ({
+  projectRoot: root,
+  platform,
+  runOptions,
+});
+
+const installFakeFingerprintEngine = (hash: string) => {
+  const packageRoot = path.join(
+    projectRoot,
+    "node_modules",
+    "@expo",
+    "fingerprint"
+  );
+  fs.mkdirSync(packageRoot, { recursive: true });
+  fs.writeFileSync(
+    path.join(packageRoot, "package.json"),
+    JSON.stringify({
+      name: "@expo/fingerprint",
+      version: "0.20.7-test",
+      main: "index.js",
+    })
+  );
+  fs.writeFileSync(
+    path.join(packageRoot, "index.js"),
+    `exports.createFingerprintAsync = async () => ({
+      hash: process.env.EAS_LOCAL_CACHE_TEST_UNIT_HASH || ${JSON.stringify(
+        hash
+      )},
+      sources: [{
+        type: "contents",
+        id: "expoConfig",
+        hash: process.env.EAS_LOCAL_CACHE_TEST_UNIT_DIGEST || "abc123",
+        reasons: ["expoConfig"],
+        contents: "must-not-persist",
+      }],
+    });\n`
+  );
+};
 
 const makeApk = (name: string, contents = "not-really-an-apk") => {
   const apk = path.join(projectRoot, name);
@@ -93,14 +156,232 @@ const entryDirectory = (
   );
 
 describe("provider resolution", () => {
-  it("returns null without creating cache state on a miss", async () => {
+  it("records a miss without creating an artifact entry", async () => {
     const result = await resolveBuildCache(
       resolveProps("android", "abc123"),
       {}
     );
 
     expect(result).toBeNull();
-    expect(fs.existsSync(cacheDir)).toBe(false);
+    const paths = getCachePaths(projectRoot);
+    expect(fs.existsSync(paths.entriesRoot)).toBe(false);
+    expect(scanResolveEvents(paths.eventsRoot).events).toHaveLength(1);
+  });
+
+  it("preserves Expo hash parity and publishes bounded insight telemetry", async () => {
+    installFakeFingerprintEngine("lifecycle-hash");
+
+    const firstHash = await calculateFingerprintHash(
+      calculateProps("android"),
+      {}
+    );
+    expect(firstHash).toBe("lifecycle-hash");
+    expect(
+      await resolveBuildCache(resolveProps("android", "lifecycle-hash"), {})
+    ).toBeNull();
+
+    const apk = makeApk("lifecycle.apk");
+    const secondHash = await calculateFingerprintHash(
+      calculateProps("android"),
+      {}
+    );
+    expect(secondHash).toBe(firstHash);
+    const cached = await uploadBuildCache(
+      uploadProps("android", "lifecycle-hash", apk),
+      {}
+    );
+    expect(cached).not.toBeNull();
+
+    const insight = readInsight(entryDirectory("android", "lifecycle-hash"));
+    expect(insight?.fingerprintHash).toBe("lifecycle-hash");
+    expect(JSON.stringify(insight)).not.toContain("must-not-persist");
+
+    await calculateFingerprintHash(calculateProps("android"), {});
+    expect(
+      await resolveBuildCache(resolveProps("android", "lifecycle-hash"), {})
+    ).toBe(cached);
+    const events = scanResolveEvents(getCachePaths(projectRoot).eventsRoot);
+    expect(events.events.map(({ event }) => event.outcome)).toEqual([
+      "miss",
+      "hit",
+    ]);
+  });
+
+  it("explains an Expo config fingerprint change from prior evidence", async () => {
+    installFakeFingerprintEngine("fallback");
+    const log = spyOn(console, "log").mockImplementation(() => {});
+    try {
+      process.env.EAS_LOCAL_CACHE_TEST_UNIT_HASH = "config-a";
+      process.env.EAS_LOCAL_CACHE_TEST_UNIT_DIGEST = "aaaa";
+      await calculateFingerprintHash(calculateProps("android"), {});
+      await resolveBuildCache(resolveProps("android", "config-a"), {});
+      const apk = makeApk("config-a.apk");
+      await calculateFingerprintHash(calculateProps("android"), {});
+      await uploadBuildCache(uploadProps("android", "config-a", apk), {});
+
+      process.env.EAS_LOCAL_CACHE_TEST_UNIT_HASH = "config-b";
+      process.env.EAS_LOCAL_CACHE_TEST_UNIT_DIGEST = "bbbb";
+      await calculateFingerprintHash(calculateProps("android"), {});
+      expect(
+        await resolveBuildCache(resolveProps("android", "config-b"), {})
+      ).toBeNull();
+      expect(log).toHaveBeenCalledWith(
+        "Possible cause: Expo config or config plugins changed (1 source)"
+      );
+    } finally {
+      delete process.env.EAS_LOCAL_CACHE_TEST_UNIT_HASH;
+      delete process.env.EAS_LOCAL_CACHE_TEST_UNIT_DIGEST;
+      log.mockRestore();
+    }
+  });
+
+  it("expires an abandoned build context before correlating a later build", async () => {
+    installFakeFingerprintEngine("expired-context");
+    let wallTimeMs = Date.now();
+    const dateNow = spyOn(Date, "now").mockImplementation(() => wallTimeMs);
+    try {
+      process.env.EAS_LOCAL_CACHE_TEST_UNIT_HASH = "expired-context";
+      await calculateFingerprintHash(calculateProps("android"), {});
+      await resolveBuildCache(resolveProps("android", "expired-context"), {});
+
+      wallTimeMs += 30 * 60 * 1000 + 1;
+      await calculateFingerprintHash(calculateProps("android"), {});
+      await resolveBuildCache(resolveProps("android", "expired-context"), {});
+
+      const apk = makeApk("expired-context.apk");
+      await calculateFingerprintHash(calculateProps("android"), {});
+      fs.utimesSync(
+        apk,
+        new Date(wallTimeMs + 1_000),
+        new Date(wallTimeMs + 1_000)
+      );
+      wallTimeMs += 2_000;
+      await uploadBuildCache(
+        uploadProps("android", "expired-context", apk),
+        {}
+      );
+
+      const insight = readInsight(entryDirectory("android", "expired-context"));
+      expect(insight?.artifactReadyEstimate?.method).toBe("artifact-mtime-v1");
+      expect(insight?.artifactReadyEstimate?.durationMs).toBe(1_000);
+    } finally {
+      delete process.env.EAS_LOCAL_CACHE_TEST_UNIT_HASH;
+      dateNow.mockRestore();
+    }
+  });
+
+  it("bounds abandoned calculation contexts in a long-lived host", async () => {
+    installFakeFingerprintEngine("bounded-context");
+    let wallTimeMs = Date.now();
+    const dateNow = spyOn(Date, "now").mockImplementation(() => wallTimeMs);
+    try {
+      process.env.EAS_LOCAL_CACHE_TEST_UNIT_HASH = "bounded-context";
+      for (let index = 0; index <= 128; index += 1) {
+        await calculateFingerprintHash(
+          calculateProps("android", projectRoot, {
+            variant: `bounded-${index}`,
+          }),
+          {}
+        );
+        wallTimeMs += 1;
+      }
+
+      await uploadBuildCache(
+        uploadProps(
+          "android",
+          "bounded-context",
+          makeApk("bounded-context.apk"),
+          projectRoot,
+          { variant: "bounded-0" }
+        ),
+        {}
+      );
+      expect(
+        readInsight(entryDirectory("android", "bounded-context"))
+      ).toBeNull();
+
+      // Move beyond the lifecycle TTL so this test leaves no abandoned state.
+      wallTimeMs += 30 * 60 * 1000 + 1;
+      await calculateFingerprintHash(
+        calculateProps("android", projectRoot, { variant: "cleanup" }),
+        {}
+      );
+      await uploadBuildCache(
+        uploadProps(
+          "android",
+          "bounded-context",
+          makeApk("bounded-cleanup.apk"),
+          projectRoot,
+          { variant: "cleanup" }
+        ),
+        {}
+      );
+    } finally {
+      delete process.env.EAS_LOCAL_CACHE_TEST_UNIT_HASH;
+      dateNow.mockRestore();
+    }
+  });
+
+  it("does not correlate timing when the post-build fingerprint changed", async () => {
+    installFakeFingerprintEngine("fallback");
+    try {
+      process.env.EAS_LOCAL_CACHE_TEST_UNIT_HASH = "before-build";
+      process.env.EAS_LOCAL_CACHE_TEST_UNIT_DIGEST = "aaaa";
+      await calculateFingerprintHash(calculateProps("android"), {});
+      await resolveBuildCache(resolveProps("android", "before-build"), {});
+
+      process.env.EAS_LOCAL_CACHE_TEST_UNIT_HASH = "after-build";
+      process.env.EAS_LOCAL_CACHE_TEST_UNIT_DIGEST = "bbbb";
+      await calculateFingerprintHash(calculateProps("android"), {});
+      await uploadBuildCache(
+        uploadProps(
+          "android",
+          "after-build",
+          makeApk("changed-post-build.apk")
+        ),
+        {}
+      );
+
+      const insight = readInsight(entryDirectory("android", "after-build"));
+      expect(insight?.fingerprintHash).toBe("after-build");
+      expect(insight?.artifactReadyEstimate).toBeUndefined();
+      expect(fs.existsSync(entryDirectory("android", "before-build"))).toBe(
+        false
+      );
+    } finally {
+      delete process.env.EAS_LOCAL_CACHE_TEST_UNIT_HASH;
+      delete process.env.EAS_LOCAL_CACHE_TEST_UNIT_DIGEST;
+    }
+  });
+
+  it("does not cross-correlate two unresolved builds with the same identity", async () => {
+    installFakeFingerprintEngine("ambiguous-context");
+    try {
+      process.env.EAS_LOCAL_CACHE_TEST_UNIT_HASH = "ambiguous-context";
+      await calculateFingerprintHash(calculateProps("android"), {});
+      await Promise.all([
+        resolveBuildCache(resolveProps("android", "ambiguous-context"), {}),
+        resolveBuildCache(resolveProps("android", "ambiguous-context"), {}),
+      ]);
+
+      await calculateFingerprintHash(calculateProps("android"), {});
+      await uploadBuildCache(
+        uploadProps(
+          "android",
+          "ambiguous-context",
+          makeApk("ambiguous-context.apk")
+        ),
+        {}
+      );
+
+      const insight = readInsight(
+        entryDirectory("android", "ambiguous-context")
+      );
+      expect(insight?.fingerprintHash).toBe("ambiguous-context");
+      expect(insight?.artifactReadyEstimate).toBeUndefined();
+    } finally {
+      delete process.env.EAS_LOCAL_CACHE_TEST_UNIT_HASH;
+    }
   });
 
   it("isolates fingerprints and platforms", async () => {

--- a/test/timing.test.ts
+++ b/test/timing.test.ts
@@ -1,0 +1,131 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import * as fs from "fs";
+import * as os from "os";
+import * as path from "path";
+
+import {
+  ARTIFACT_MTIME_METHOD,
+  elapsedMilliseconds,
+  estimateArtifactReadyDuration,
+  estimateTimeSaved,
+} from "../src/cache/timing";
+
+const root = fs.realpathSync(
+  fs.mkdtempSync(path.join(os.tmpdir(), "eas-local-cache-timing-"))
+);
+
+afterEach(() => {
+  fs.rmSync(root, { recursive: true, force: true });
+  fs.mkdirSync(root, { recursive: true });
+});
+
+const setMtime = (candidate: string, timestampMs: number): void => {
+  const date = new Date(timestampMs);
+  fs.utimesSync(candidate, date, date);
+};
+
+describe("artifact timing", () => {
+  it("uses an APK mtime only inside the safe build window", () => {
+    const artifactPath = path.join(root, "artifact.apk");
+    fs.writeFileSync(artifactPath, "apk");
+    setMtime(artifactPath, 15_000);
+
+    expect(
+      estimateArtifactReadyDuration({
+        artifactPath,
+        platform: "android",
+        missStartedAtMs: 10_000,
+        uploadObservedAtMs: 20_000,
+      })
+    ).toEqual({ durationMs: 5_000, method: ARTIFACT_MTIME_METHOD });
+
+    setMtime(artifactPath, 9_999);
+    expect(
+      estimateArtifactReadyDuration({
+        artifactPath,
+        platform: "android",
+        missStartedAtMs: 10_000,
+        uploadObservedAtMs: 20_000,
+      })
+    ).toBeNull();
+
+    setMtime(artifactPath, 22_001);
+    expect(
+      estimateArtifactReadyDuration({
+        artifactPath,
+        platform: "android",
+        missStartedAtMs: 10_000,
+        uploadObservedAtMs: 20_000,
+      })
+    ).toBeNull();
+  });
+
+  it("uses the newest regular file in an app without following symlinks", () => {
+    const artifactPath = path.join(root, "artifact.app");
+    fs.mkdirSync(path.join(artifactPath, "Frameworks"), { recursive: true });
+    const binary = path.join(artifactPath, "App");
+    const framework = path.join(artifactPath, "Frameworks", "Library");
+    fs.writeFileSync(binary, "binary");
+    fs.writeFileSync(framework, "framework");
+    setMtime(binary, 12_000);
+    setMtime(framework, 14_000);
+    const outside = path.join(root, "outside");
+    fs.writeFileSync(outside, "outside");
+    setMtime(outside, 99_000);
+    fs.symlinkSync(outside, path.join(artifactPath, "unsafe-link"));
+
+    expect(
+      estimateArtifactReadyDuration({
+        artifactPath,
+        platform: "ios",
+        missStartedAtMs: 10_000,
+        uploadObservedAtMs: 20_000,
+      })
+    ).toEqual({ durationMs: 4_000, method: ARTIFACT_MTIME_METHOD });
+  });
+
+  it("rejects unsafe artifact types, empty apps, and durations above six hours", () => {
+    const emptyApp = path.join(root, "empty.app");
+    fs.mkdirSync(emptyApp);
+    expect(
+      estimateArtifactReadyDuration({
+        artifactPath: emptyApp,
+        platform: "ios",
+        missStartedAtMs: 0,
+        uploadObservedAtMs: 1_000,
+      })
+    ).toBeNull();
+
+    const target = path.join(root, "target.apk");
+    const link = path.join(root, "link.apk");
+    fs.writeFileSync(target, "apk");
+    fs.symlinkSync(target, link);
+    expect(
+      estimateArtifactReadyDuration({
+        artifactPath: link,
+        platform: "android",
+        missStartedAtMs: 0,
+        uploadObservedAtMs: 1_000,
+      })
+    ).toBeNull();
+
+    setMtime(target, 6 * 60 * 60 * 1000 + 1);
+    expect(
+      estimateArtifactReadyDuration({
+        artifactPath: target,
+        platform: "android",
+        missStartedAtMs: 0,
+        uploadObservedAtMs: 7 * 60 * 60 * 1000,
+      })
+    ).toBeNull();
+  });
+
+  it("measures lookup time monotonically and never invents savings", () => {
+    expect(elapsedMilliseconds(1_000_000n, 4_500_000n)).toBe(3.5);
+    expect(elapsedMilliseconds(4n, 3n)).toBe(0);
+    expect(estimateTimeSaved(1_000, 25)).toBe(975);
+    expect(estimateTimeSaved(10, 20)).toBe(0);
+    expect(estimateTimeSaved(undefined, 20)).toBeUndefined();
+    expect(estimateTimeSaved(Number.NaN, 20)).toBeUndefined();
+  });
+});


### PR DESCRIPTION
Recovery for #20, which was accidentally merged into its stacked base branch instead of main. This PR replays the same final tree change directly onto main.\n\nExplain local cache misses with privacy-safe Expo fingerprint evidence and expose retained hit-rate and conservative time-saved telemetry without making diagnostics part of cache correctness.

## What changed

- preserve Expo fingerprint hash parity while retaining bounded, sanitized source evidence
- explain likely Expo config, native dependency, native project, metadata, and other fingerprint changes
- record atomic, private resolve events with strict 90-day and 10,000-event limits
- report hit rate and conservative artifact-mtime-based savings through Cache Inspector
- validate optional insights with `doctor` and prune telemetry separately from artifact capacity
- add a repeatable HeroUI example oracle for miss, hit, explained config miss, and hit

## Testing

- `bun run format:check`
- `bun run lint`
- `bun run typecheck`
- `bun test` — 112 tests, 398 assertions
- `bun run build`
- `bun run example:check`
- `bunx expo export --platform ios --output-dir .expo/export-smoke` — 2,343 modules
- installed the packed tarball into an isolated npm consumer and verified all provider callbacks
- `EAS_LOCAL_CACHE_TEST_DEVICE=generic bun run --cwd example cache:test:ios` — A miss/upload, A hit, B explained Expo config miss/upload, B hit, exact telemetry delta, diagnostic privacy scan, and healthy doctor result

## Risk

Fingerprint diagnostics and telemetry are fail-open and bounded. Existing artifact validation remains authoritative, pre-feature entries remain readable, and malformed optional insight/event data never turns a valid artifact into a cache miss.