### PR TITLE
docs(readme): clarify physical device cache support

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,18 @@ Supported project types:
 | Bare project using Expo CLI `expo run:*` | Yes |
 | Pure React Native CLI `react-native run-*` | No |
 | `eas build` or `eas build --local` | No |
-| Physical iOS device build | No; Expo only invokes this provider for Simulator builds |
+
+Supported build targets:
+
+| Target | Cache supported? |
+| --- | ---: |
+| Android Emulator | Yes |
+| Android physical device | Yes |
+| iOS Simulator | Yes |
+| iPhone or iPad physical device | No; Expo CLI skips build-cache providers for physical iOS builds |
+
+The physical iOS limitation comes from Expo CLI, not this package. See Expo's
+[build cache provider limitations](https://docs.expo.dev/guides/cache-builds-remotely/#limitations).
 
 ## Install
 


### PR DESCRIPTION
Clarifies which physical devices can use the Expo build-cache provider so developers do not interpret the iOS limitation as applying to Android.

## What changed

- add a dedicated build-target support table
- state that Android emulators and physical Android devices are supported
- state that Expo CLI skips cache lookup and upload for physical iPhone and iPad builds
- link to Expo's official build-cache provider limitations

## Testing

- `bun run format:check`
- `git diff --check`

Runtime and native tests were not run because this change only updates README content.

## Risk

Documentation-only change with no package or runtime behavior impact.
